### PR TITLE
Rhombus Mute/Solo & Track Import Fix

### DIFF
--- a/app/assets/templates/track.html.erb
+++ b/app/assets/templates/track.html.erb
@@ -58,6 +58,26 @@
           rhomb._song._tracks.getObjById(parseInt(root.getElementById("track_index").value))._name = event.detail.value;
 				});
 
+				root.getElementById("mute").addEventListener('mouseup', function(){
+					track_object.index = root.getElementById("track_index").value;
+					track_object.id = root.getElementById("track_id").value;
+
+					// TODO: figure out why this needs to be inverted
+					track_object.value = !event.srcElement.checked;
+					var muteEvent = new CustomEvent('denoto-mutetrack', {"detail": {"div": root.host, "track": track_object}});
+					document.dispatchEvent(muteEvent);
+				});
+
+				root.getElementById("solo").addEventListener('mouseup', function(){
+					track_object.index = root.getElementById("track_index").value;
+					track_object.id = root.getElementById("track_id").value;
+
+					// TODO: figure out why this needs to be inverted
+					track_object.value = !event.srcElement.checked;
+					var soloEvent = new CustomEvent('denoto-solotrack', {"detail": {"div": root.host, "track": track_object}});
+					document.dispatchEvent(soloEvent);
+				});
+
 				root.getElementById("delete").addEventListener('mouseup', function(){
 					var deleteThis = confirm("This will permanently delete the track and associated pattern timings.");
 					if(deleteThis){

--- a/app/assets/templates/tracklist.html.erb
+++ b/app/assets/templates/tracklist.html.erb
@@ -95,7 +95,7 @@
         root.getElementById('tracklist').removeChild(event.detail.div);
         tracks--;
 
-        rhomb._song.deleteTrack(event.detail.track.index);
+        rhomb._song.deleteTrack(event.detail.track.id);
 
         //root.getElementById("rowcover").style.top = (root.getElementById("addbutton").getBoundingClientRect().top - 195) + "px";
 

--- a/app/assets/templates/trackview.html.erb
+++ b/app/assets/templates/trackview.html.erb
@@ -544,6 +544,14 @@
           		redrawEverything();
 			});
 
+			document.addEventListener('denoto-mutetrack', function(){
+				rhomb._song._tracks.getObjById(event.detail.track.id).setMute(event.detail.track.value);
+			});
+
+			document.addEventListener('denoto-solotrack', function(){
+				rhomb._song._tracks.getObjById(event.detail.track.id).setSolo(event.detail.track.value);
+			});
+
 			document.addEventListener('denoto-setheights', function(){
 				setHeights(event.detail.height);
 				redrawEverything();

--- a/app/assets/templates/trackview.html.erb
+++ b/app/assets/templates/trackview.html.erb
@@ -453,9 +453,9 @@
 
 				// add the song's tracks
 				var count = 0;
-				var tracks = rhomb._song._tracks;
-				for(var index in tracks){
-					var track = tracks[index];
+				var slots = rhomb._song._tracks._slots;
+				for(var index in slots) {
+					var track = rhomb._song._tracks.getObjBySlot(index);
 					var trackEvent = new CustomEvent("denoto-addtrack", {"detail": {"index": index, "track": track}});
 					document.dispatchEvent(trackEvent);
 


### PR DESCRIPTION
Tracks can now be muted or soloed, using setMute(boolean) and setSolo(boolean), which are properties of Track objects. It's also possible to query and toggle the mute/solo state of tracks.

I also fixed a small bug which prevented the track view from being populated correctly when re-opening saved songs in the editor.

[EDIT]
It would appear as though song import is buggy. Track IDs and slot indexes are not being restored properly. Will investigate. The problems aren't related to this pull request.
