### PR TITLE
Rhombs Song Import Fixes

### DIFF
--- a/app/assets/javascripts/rhombus.js
+++ b/app/assets/javascripts/rhombus.js
@@ -59,7 +59,8 @@
 
       Object.defineProperty(t, '_id', {
         value: id,
-        enumerable: true
+        enumerable: true,
+        writable: true
       });
     };
 
@@ -1583,6 +1584,10 @@
 
     r.Track.prototype = {
 
+      setId: function(id) {
+        this._id = id;
+      },
+
       getName: function() {
         return this._name;
       },
@@ -1790,11 +1795,6 @@
         var track = new r.Track();
         this._tracks.addObj(track);
 
-        // Create a new Instrument and set it as the new Track's target
-        var instrId = r.addInstrument("mono");
-        r._song._instruments.getObjById(instrId).normalizedObjectSet({ volume: 0.1 });
-        track._target = instrId;
-
         // Return the ID of the new Track
         return track._id;
       },
@@ -1871,7 +1871,8 @@
         var pattern = patterns[ptnId];
         var noteMap = pattern._noteMap;
 
-        var newPattern = new r.Pattern(pattern._id);
+        var newPattern = new r.Pattern();
+        newPattern._id = pattern._id;
 
         newPattern._name = pattern._name;
         newPattern._length = pattern._length;
@@ -1891,11 +1892,13 @@
       }
 
       for (var trkIdIdx in tracks._slots) {
-        var trkId = tracks._slots[trkIdIdx];
+        var trkId = +tracks._slots[trkIdIdx];
         var track = tracks._map[trkId];
         var playlist = track._playlist;
 
-        var newTrack = new r.Track(track._id);
+        // Create a new track and manually set its ID
+        var newTrack = new r.Track();
+        newTrack._id = trkId;
 
         newTrack._name = track._name;
         newTrack._target = +track._target;
@@ -1917,6 +1920,7 @@
         var instId = instruments._slots[instIdIdx];
         var inst = instruments._map[instId];
         r.addInstrument(inst._type, inst._params, +instId, instIdIdx);
+        r._song._instruments.getObjById(instId)._id = instId;
         r._song._instruments.getObjById(instId).normalizedObjectSet({ volume: 0.1 });
       }
 

--- a/app/assets/templates/tracklist.html.erb
+++ b/app/assets/templates/tracklist.html.erb
@@ -86,6 +86,11 @@
           var index = rhomb._song.addTrack();
           var track = rhomb._song._tracks.getObjById(index);
 
+          // Create a new Instrument and set it as the new Track's target
+          var instrId = rhomb.addInstrument("mono");
+          rhomb._song._instruments.getObjById(instrId).normalizedObjectSet({ volume: 0.1 });
+          track._target = instrId;
+
           var trackEvent = new CustomEvent("denoto-addtrack", {"detail": {"index": index, "track": track}});
           document.dispatchEvent(trackEvent);
         }


### PR DESCRIPTION
I have fixed some song import bugs that prevented IDs and indexes from being restored correctly when importing saved songs. I also moved the logic for creating new instruments and associating them with tracks from Rhombus to the music application.
