### PR TITLE
Rhombus Update & Loop Range Fix

### DIFF
--- a/app/assets/javascripts/rhombus.js
+++ b/app/assets/javascripts/rhombus.js
@@ -1927,6 +1927,12 @@
           // TODO: Figure out why this doesn't work
           //r.removeInstrument(track._target);
 
+          // Remove the track from the solo list, if it's soloed
+          var index = r._song._soloList.indexOf(track._id);
+          if (index > -1) {
+            r._song._soloList.splice(index, 1);
+          }
+
           var slot = this._tracks.getSlotById(trkId);
           var track = this._tracks.removeId(trkId);
 

--- a/app/assets/templates/loopcontrol.html.erb
+++ b/app/assets/templates/loopcontrol.html.erb
@@ -1,99 +1,112 @@
 <template>
-	<span id="loopcontrol">	
-	  Loop start: <denoto-editabletext id="loopstart" type="shorttext" value="0" width="50"></denoto-editabletext>
-	  Loop end: <denoto-editabletext id="loopend" type="shorttext" value="1920" width="50"></denoto-editabletext>
-	</span>
-	<div id="spacer"></div>
-	<style>
-		#loopcontrol {
-			opacity: 0.9;
-			position: relative;
-			top: 10px;
-			display: none; /* by default, this element should be invisible. It shows up when loop is enabled */
-		}
-		#spacer{
-			display: inline-block;
-			width: 222px;
-		}
-	</style>
+  <span id="loopcontrol"> 
+    Loop start: <denoto-editabletext id="loopstart" type="shorttext" value="0" width="50"></denoto-editabletext>
+    Loop end: <denoto-editabletext id="loopend" type="shorttext" value="1920" width="50"></denoto-editabletext>
+  </span>
+  <div id="spacer"></div>
+  <style>
+    #loopcontrol {
+      opacity: 0.9;
+      position: relative;
+      top: 10px;
+      display: none; /* by default, this element should be invisible. It shows up when loop is enabled */
+    }
+    #spacer{
+      display: inline-block;
+      width: 222px;
+    }
+  </style>
 </template>
 
 <script>
-	(function(){
-		// get the template for this element
-		var template = document.currentScript.ownerDocument.querySelector('template');
+  (function(){
+    // get the template for this element
+    var template = document.currentScript.ownerDocument.querySelector('template');
 
-		// copy a prototype from HTMLElement
-		var loopcontrolPrototype = Object.create(HTMLElement.prototype);
+    // copy a prototype from HTMLElement
+    var loopcontrolPrototype = Object.create(HTMLElement.prototype);
 
-		// specify the created callback ("constructor")
-		loopcontrolPrototype.createdCallback = function(){
-			var root = this.createShadowRoot();
-			root.appendChild(document.importNode(template.content, true));
+    // specify the created callback ("constructor")
+    loopcontrolPrototype.createdCallback = function(){
+      var root = this.createShadowRoot();
+      root.appendChild(document.importNode(template.content, true));
 
-			// get references to the transport bar's buttons
-			var loopstart = root.querySelector('#loopstart');
-			var loopend = root.querySelector('#loopend');
+      // get references to the transport bar's buttons
+      var loopstart = root.querySelector('#loopstart');
+      var loopend = root.querySelector('#loopend');
 
-			var oldstart = loopstart.value;
-			var oldend = loopend.value;
+      loopstart.value = 0;
+      loopend.value = 1920;
 
-			// make the buttons react when clicked on
-			loopstart.addEventListener('keyup', 
-				function(){
-					if(event.keyCode == 13 && parseInt(loopstart.value) < parseInt(loopend.value)){
-						var keyEvent = new CustomEvent("denoto-updateloopstart", {"detail": {"start": parseInt(loopstart.value)}});
-						// dispatch to the document
-						root.host.dispatchEvent(keyEvent);
-						document.dispatchEvent(keyEvent);
-						oldstart = loopstart.value;
-					} else {
-						loopstart.setAttribute("value", oldstart);
-					}
-				});
+      var oldstart = loopstart.value;
+      var oldend = loopend.value;
 
-			loopend.addEventListener('keyup', 
-				function(){
-					if(event.keyCode == 13 && parseInt(loopstart.value) < parseInt(loopend.value)){
-						var keyEvent = new CustomEvent("denoto-updateloopend", {"detail": {"end": parseInt(loopend.value)}});
-						// dispatch to the document
-						root.host.dispatchEvent(keyEvent);
-						document.dispatchEvent(keyEvent);
-						oldend = loopend.value;
-					} else {
-						loopend.setAttribute("value", oldend);
-					}
-				});
+      // make the buttons react when clicked on
+      loopstart.addEventListener('keyup', 
+        function(){
 
-			document.addEventListener('denoto-updateloopstart',
-				function(){
-					loopstart.setAttribute("value", event.detail.start);
-					oldstart = event.detail.start;
-				});
+          var start = parseInt(loopstart.value);
+          var end = parseInt(loopend.value);
 
-			document.addEventListener('denoto-updateloopend',
-				function(){
-					loopend.setAttribute("value", event.detail.end);
-					oldend = event.detail.end;
-				});
+          if(event.keyCode == 13 && start < end && (end - start) >= 480) {
+            console.log("[LoopControl] Updating loop start to " + start);
+            var keyEvent = new CustomEvent("denoto-updateloopstart", {"detail": {"start": start}});
+            // dispatch to the document
+            root.host.dispatchEvent(keyEvent);
+            document.dispatchEvent(keyEvent);
+            oldstart = loopstart.value;
+          } else {
+            loopstart.setAttribute("value", oldstart);
+          }
+        });
 
-			document.getElementById("transportbar").addEventListener("denoto-loopToggle",
-				function(){
-					var control = root.querySelector("#loopcontrol");
-					var spacer = root.querySelector("#spacer");
-					if(control.style.display === "inline"){
-						control.style.display = "none";
-						spacer.style.display = "inline-block";
-					}
-					else
-					{
-						control.style.display = "inline";
-						spacer.style.display = "none";
-					}
-				});
-		};
+      loopend.addEventListener('keyup', 
+        function(){
 
-		// register the element
-		var loopcontrol = document.registerElement('denoto-loopcontrol', {prototype: loopcontrolPrototype});
-	})();
+          var start = parseInt(loopstart.value);
+          var end = parseInt(loopend.value);
+
+          if(event.keyCode == 13 && start < end && (end - start) >= 480) {            
+            console.log("[LoopControl] Updating loop end to " + end);
+            var keyEvent = new CustomEvent("denoto-updateloopend", {"detail": {"end": end}});
+            // dispatch to the document
+            root.host.dispatchEvent(keyEvent);
+            document.dispatchEvent(keyEvent);
+            oldend = loopend.value;
+          } else {
+            loopend.setAttribute("value", oldend);
+          }
+        });
+
+      document.addEventListener('denoto-updateloopstart',
+        function(){
+          loopstart.setAttribute("value", event.detail.start);
+          oldstart = event.detail.start;
+        });
+
+      document.addEventListener('denoto-updateloopend',
+        function(){
+          loopend.setAttribute("value", event.detail.end);
+          oldend = event.detail.end;
+        });
+
+      document.getElementById("transportbar").addEventListener("denoto-loopToggle",
+        function(){
+          var control = root.querySelector("#loopcontrol");
+          var spacer = root.querySelector("#spacer");
+          if(control.style.display === "inline"){
+            control.style.display = "none";
+            spacer.style.display = "inline-block";
+          }
+          else
+          {
+            control.style.display = "inline";
+            spacer.style.display = "none";
+          }
+        });
+    };
+
+    // register the element
+    var loopcontrol = document.registerElement('denoto-loopcontrol', {prototype: loopcontrolPrototype});
+  })();
 </script>

--- a/app/assets/templates/pianoroll.html.erb
+++ b/app/assets/templates/pianoroll.html.erb
@@ -875,7 +875,10 @@
 				});
 
 				document.addEventListener('denoto-updatequantization', function(){
-					displaySettings.quantization = 1920 / event.detail.value;
+
+					console.log("[Pianoroll] Setting quantization to " + event.detail.value);
+
+					displaySettings.quantization = event.detail.value;
 					
 					// redraw the guiding lines, etc.
 					redrawCanvas(root, displaySettings);

--- a/app/assets/templates/quantization.html.erb
+++ b/app/assets/templates/quantization.html.erb
@@ -1,7 +1,23 @@
 <template>
 	<div id="quantizationcontrol">
 		Snap to Guides <input id="snapto" type="checkbox" checked></input>
-		Quantization: <denoto-editabletext id="quantization" type="tinytext" prefix="1/" value="16" suffix=" Note"></denoto-editabletext>
+		<!--Quantization: <denoto-editabletext id="quantization" type="tinytext" prefix="1/" value="16" suffix=" Note"></denoto-editabletext>-->
+		Quantization: 
+		<select id="quantization">
+			<option value="0">1/1</option>
+			<option value="1">1/2</option>
+			<option value="2">1/4</option>
+			<option value="3">1/8</option>
+			<option value="4" selected="selected">1/16</option>
+			<option value="5">1/32</option>
+			<option value="6">1/64</option>
+			<option value="7">1/128</option>
+			<option value="8">1/4 T</option>
+			<option value="9">1/8 T</option>
+			<option value="10">1/16 T</option>
+			<option value="11">1/32 T</option>
+			<option value="12">1/64 T</option>
+		</select>
 	</div>
 	<style>
 		#quantizationcontrol{
@@ -22,6 +38,9 @@
 		// copy a prototype from HTMLElement
 		var quantizationcontrolPrototype = Object.create(HTMLElement.prototype);
 
+		// tick lengths for the various quantization divisions
+		var quant_values = [1920, 960, 480, 240, 120, 60, 30, 15, 320, 160, 80, 40, 20];
+
 		// specify the created callback ("constructor")
 		quantizationcontrolPrototype.createdCallback = function(){
 			var root = this.createShadowRoot();
@@ -30,14 +49,12 @@
 			quant = root.querySelector("#quantization");
 			snapto = root.querySelector("#snapto");
 
-			quant.addEventListener('keyup', function(){
-				if(event.keyCode == 13){
+			quant.addEventListener('change', function(){
 					// TODO: sanitize inputs
 					var input = parseInt(event.srcElement.value);
-					var timeEvent = new CustomEvent("denoto-updatequantization", {"detail": {"value": input}});
+					var timeEvent = new CustomEvent("denoto-updatequantization", {"detail": {"value": quant_values[input]}});
 					document.dispatchEvent(timeEvent);
-				}
-			});
+				});
 
 			snapto.addEventListener('change', 
 				function(){

--- a/app/assets/templates/trackview.html.erb
+++ b/app/assets/templates/trackview.html.erb
@@ -301,7 +301,7 @@
 <script>
     (function(){
     	// keep track of display settings like ticks per pixel (AKA zoom level), and whether to show measure guides
-    	var displaySettings = {TPP: 16, showguides: true, loopEnabled: false, quantization: (1920 / 16), timesig_num: 4, timesig_den: 4, snapto: true, endmarkerticks: 4 * 7680, maxmeasures: 20};
+    	var displaySettings = {TPP: 16, showguides: true, loopEnabled: false, quantization: 120, timesig_num: 4, timesig_den: 4, snapto: true, endmarkerticks: 4 * 7680, maxmeasures: 20};
 
     	// used to hold the node if it is detached from the DOM
     	var trackviewholder;
@@ -858,7 +858,7 @@
 				});
 
 				document.addEventListener('denoto-updatequantization', function(){
-					displaySettings.quantization = 1920 / event.detail.value;
+					displaySettings.quantization = event.detail.value;
 					
 					// redraw the guiding lines, etc.
 					redrawTracksCanvas(root, displaySettings);

--- a/app/views/tracks/new.html.erb
+++ b/app/views/tracks/new.html.erb
@@ -160,12 +160,10 @@
   document.addEventListener("denoto-updateloopstart", updateLoopStart);
   document.addEventListener("denoto-updateloopend", updateLoopEnd);
 
-  function updateLoopStart(e){ 
-    console.log("[LoopControl] Updating loop start to " + event.detail.start);
+  function updateLoopStart(e){    
     rhomb.setLoopStart(event.detail.start);
   }
-  function updateLoopEnd(e){ 
-    console.log("[LoopControl] Updating loop end to " + event.detail.end);
+  function updateLoopEnd(e){    
     rhomb.setLoopEnd(event.detail.end);
   }
   

--- a/app/views/tracks/new.html.erb
+++ b/app/views/tracks/new.html.erb
@@ -39,7 +39,7 @@
     width: 100%;
     position: fixed;
     top: 51px;
-    z-index: 4;
+    z-index: 5;
     padding: 10px;
     color: #FFFFFF;
   }


### PR DESCRIPTION
This is a small update which fixes the behavior of Rhombus when a soloed track is deleted. I also restored functionality to the loop start and end editable text boxes, and imposed the constraint that the loop range must be at least 480 ticks. This constraint doesn't (yet) apply to loop ranges that are manually drawn.

P.S. I just added a drop-down menu for quantization values.
