### PR TITLE
Note Velocity

### DIFF
--- a/app/assets/javascripts/Tone.js
+++ b/app/assets/javascripts/Tone.js
@@ -1282,7 +1282,7 @@
 			var attack = this.toSeconds(this.attack);
 			var decay = this.toSeconds(this.decay);
 			var scaledMax = velocity;
-			var sustainVal = this.sustain;
+			var sustainVal = this.sustain * scaledMax;
 			time = this.toSeconds(time);
 			this._sig.cancelScheduledValues(time);
 			this._sig.setTargetAtTime(scaledMax, time, attack * this._timeMult);

--- a/app/assets/javascripts/noteset.js
+++ b/app/assets/javascripts/noteset.js
@@ -34,7 +34,7 @@ NoteSet.prototype.AddNote = function(note){
 	if(typeof note.ID === 'undefined'){
 		// assign a new ID to the note
 		// TODO: fix temporary keyValue shift
-		var rnote = new rhomb.Note(this.lanes.length + 35 - note.keyValue, note.tickstart, note.tickduration);
+		var rnote = new rhomb.Note(this.lanes.length + 35 - note.keyValue, note.tickstart, note.tickduration, +note.velocity);
 		note.rnote = rnote;
 		note.ID = rnote._id;
 	}

--- a/app/assets/javascripts/rhombus.js
+++ b/app/assets/javascripts/rhombus.js
@@ -932,7 +932,7 @@
       // TODO: default params here
     };
 
-    Sampler.prototype.triggerAttack = function(id, pitch, delay) {
+    Sampler.prototype.triggerAttack = function(id, pitch, delay, velocity) {
       if (this.samples.length === 0) {
         return;
       }
@@ -944,15 +944,18 @@
       var idx = pitch % this.samples.length;
       this._triggered[id] = idx;
 
+      velocity = +velocity || 1;
+
       // TODO: real keyzones, pitch control, etc.
       if (delay > 0) {
-        this.samples[idx].triggerAttack(0, "+" + delay);
+        this.samples[idx].triggerAttack(0, "+" + delay, velocity);
       } else {
-        this.samples[idx].triggerAttack(0);
+        this.samples[idx].triggerAttack(0, "+" + 0, velocity);
       }
     };
 
     Sampler.prototype.triggerRelease = function(id, delay) {
+      delete this._triggered[id];
       return;
       // HACK: maybe leaking
       /*
@@ -1192,7 +1195,6 @@
         r._setId(this, id);
       }
 
-
       this._type = type;
       this._currentParams = {};
       this._triggered = {};
@@ -1202,6 +1204,7 @@
       this._normalizedObjectSet(def, true);
       this._normalizedObjectSet(options, true);
     }
+
     Tone.extend(Instrument, Tone.PolySynth);
     r._addGraphFunctions(Instrument);
 
@@ -1259,7 +1262,7 @@
       r._song._instruments.removeId(id);
     };
 
-    Instrument.prototype.triggerAttack = function(id, pitch, delay) {
+    Instrument.prototype.triggerAttack = function(id, pitch, delay, velocity) {
       // Don't play out-of-range notes
       if (pitch < 0 || pitch > 127) {
         return;
@@ -1269,10 +1272,12 @@
       var freq = Rhombus.Util.noteNum2Freq(pitch);
       this._triggered[id] = freq;
 
+      velocity = +velocity || 1;
+
       if (delay > 0) {
-        tA.call(this, freq, "+" + delay);
+        tA.call(this, freq, "+" + delay, velocity);
       } else {
-        tA.call(this, freq);
+        tA.call(this, freq, "+" + 0, velocity);
       }
     };
 
@@ -1284,6 +1289,7 @@
       } else {
         tR.call(this, freq);
       }
+      delete this._triggered[id];
     };
 
     Instrument.prototype.killAllNotes = function() {
@@ -1794,15 +1800,20 @@
     };
 
     // TODO: Note should probably have its own source file
-    r.Note = function(pitch, start, length, id) {
+    r.Note = function(pitch, start, length, velocity, id) {
       if (isDefined(id)) {
         r._setId(this, id);
       } else {
         r._newId(this);
       }
-      this._pitch = pitch || 60;
-      this._start = start || 0;
-      this._length = length || 0;
+
+
+      this._pitch    = +pitch    || 60;
+      this._start    = +start    || 0;
+      this._length   = +length   || 0;
+      this._velocity = +velocity || 1;
+
+      console.log("[Rhombus] - Creating note with velocity " + velocity);
     };
 
     r.Note.prototype = {
@@ -1816,6 +1827,10 @@
 
       getLength: function() {
         return this._length;
+      },
+
+      getVelocity: function() {
+        return this._velocity;
       },
 
       getEnd: function() {
@@ -2339,9 +2354,10 @@
         // dumbing down Note (e.g., by removing methods from its
         // prototype) might make deserializing much easier
         for (var noteId in noteMap) {
-          var note = new this.Note(noteMap[noteId]._pitch,
-                                   noteMap[noteId]._start,
-                                   noteMap[noteId]._length,
+          var note = new this.Note(+noteMap[noteId]._pitch,
+                                   +noteMap[noteId]._start,
+                                   +noteMap[noteId]._length,
+                                   +noteMap[noteId]._velocity || 1,
                                    +noteId);
 
           newPattern._noteMap[+noteId] = note;
@@ -2537,7 +2553,8 @@
                 var rtNote = new r.RtNote(note._pitch, startTime, endTime, track._target);
                 playingNotes[rtNote._id] = rtNote;
 
-                r._song._instruments.getObjById(track._target).triggerAttack(rtNote._id, note.getPitch(), delay);
+                var instrument = r._song._instruments.getObjById(track._target);
+                instrument.triggerAttack(rtNote._id, note.getPitch(), delay, note.getVelocity());
               }
             }
           }
@@ -2872,7 +2889,8 @@
         var srcPtnNote = srcPtn._noteMap[noteId];
         var dstNote = new r.Note(srcNote._pitch,
                                  srcNote._start,
-                                 srcNote._length);
+                                 srcNote._length,
+                                 srcNote._velocity);
 
         dstPtn._noteMap[dstNote._id] = dstNote;
       }
@@ -2922,7 +2940,7 @@
         }
 
         // Create a new note and add it to the appropriate destination pattern
-        var dstNote = new r.Note(srcNote._pitch, dstStart, dstLength);
+        var dstNote = new r.Note(srcNote._pitch, dstStart, dstLength, srcNote._velocity);
         dstPtn._noteMap[dstNote._id] = dstNote;
       }
 

--- a/app/assets/javascripts/rhombus.js
+++ b/app/assets/javascripts/rhombus.js
@@ -1807,13 +1807,10 @@
         r._newId(this);
       }
 
-
       this._pitch    = +pitch    || 60;
       this._start    = +start    || 0;
       this._length   = +length   || 0;
       this._velocity = +velocity || 1;
-
-      console.log("[Rhombus] - Creating note with velocity " + velocity);
     };
 
     r.Note.prototype = {
@@ -1833,6 +1830,7 @@
         return this._velocity;
       },
 
+      // TODO: check for off-by-one issues
       getEnd: function() {
         return this._start + this._length;
       }
@@ -2954,6 +2952,66 @@
 
       // return the pair of new IDs
       return [dstL._id, dstR._id];
+    };
+
+    // Returns an array containing all notes within a given horizontal (time) and
+    // and vertical (pitch) range.
+    //
+    // The lowNote and highNote arguments are optional. If they are undefined, all
+    // of the notes within the time range will be returned.
+    r.Edit.getNotesInRange = function(ptnId, start, end, lowNote, highNote) {
+      var srcPtn = r._song._patterns[ptnId];
+      if (notDefined(srcPtn) || !isInteger(start) || !isInteger(end)) {
+        return undefined;
+      }
+
+      // assign defaults to the optional arguments
+      lowNote  = +lowNote  || 0;
+      highNote = +highNote || 127;
+
+      var noteArray = [];
+      for (var noteId in srcPtn._noteMap) {
+        var srcNote = srcPtn._noteMap[noteId];
+        var srcStart = srcNote.getStart();
+        var srcPitch = srcNote.getPitch();
+        if (srcStart >= srcStart && srcStart < end &&
+            srcPitch >= lowNote && srcPitch <= highNote) {
+          noteArray.push(srcNote);
+        }
+      }
+
+      // TODO: decide if we should return undefined if there are no matching notes
+      return noteArray;
+    };
+
+    quantizeTick = function(tickVal, quantize) {
+      if ((tickVal % quantize) > (quantize / 2)) {
+        return (Math.floor(tickVal/quantize) * quantize) + quantize;
+      }
+      else {
+        return Math.floor(tickVal/quantize) * quantize;
+      }
+    }
+
+    r.Edit.quantizeNotes = function(notes, quantize, doEnds) {
+      for (var i = 0; i < notes.length; i++) {
+        var srcNote = notes[i]
+        var srcStart = srcNote.getStart();
+        srcNote._start = quantizeTick(srcStart, quantize);
+
+        // optionally quantize the ends of notes
+        if (doEnds === true) {
+          var srcLength = srcNote.getLength();
+          var srcEnd = srcNote.getEnd();
+
+          if (srcLength < quantize) {
+            srcNote._length = quantize;
+          }
+          else {
+            srcNote._length = quantizeTick(srcEnd, quantize) - srcNote.getStart();
+          }
+        }
+      }
     };
   };
 })(this.Rhombus);

--- a/app/assets/templates/pianoroll.html.erb
+++ b/app/assets/templates/pianoroll.html.erb
@@ -578,18 +578,22 @@
 
 			this.handleZoomIn = function(){
 				displaySettings.TPP = displaySettings.TPP / 2;
-				if(displaySettings.TPP < 1)
-					displaySettings.TPP = 1;
-
-				redrawEverything();
+				if(displaySettings.TPP < 2) {
+					displaySettings.TPP = 2
+				}
+				else {
+					redrawEverything();
+				}
 			}
 
 			this.handleZoomOut = function(){
 				displaySettings.TPP = displaySettings.TPP * 2;
-				if(displaySettings.TPP > 16)
+				if(displaySettings.TPP > 16) {
 					displaySettings.TPP = 16;
-
-				redrawEverything();
+				}
+				else {
+					redrawEverything();
+				}
 			}
 
 			// TG WAS HERE
@@ -751,45 +755,46 @@
 			}
 
 			function render(){
-				// draw the time marker on the overlay
-				redrawOverlay(root, displaySettings);
-				var ticks = rhomb.seconds2Ticks(rhomb.getPosition());
-				drawTimeMarker(overlayContext, ticks, overlayCanvas.getAttribute("height"), displaySettings);
+				setTimeout(function() {
+	        window.requestAnimationFrame(render);
+					// draw the time marker on the overlay
+					redrawOverlay(root, displaySettings);
+					var ticks = rhomb.seconds2Ticks(rhomb.getPosition());
+					drawTimeMarker(overlayContext, ticks, overlayCanvas.getAttribute("height"), displaySettings);
 
-				// The tick value can become negative when playback loops around
-				// This is to 'correct' the tick value so that the time display is more accurate
-				if (ticks < 0) {
-					ticks = rhomb.getLoopEnd() + ticks;
-				}
+					// The tick value can become negative when playback loops around
+					// This is to 'correct' the tick value so that the time display is more accurate
+					if (ticks < 0) {
+						ticks = rhomb.getLoopEnd() + ticks;
+					}
 
-				var beat_ticks = Math.floor((480 * 4) / displaySettings.timesig_den);
-				var measure_ticks = displaySettings.timesig_num * beat_ticks;
-				var q_beat_ticks = Math.floor(beat_ticks / 4);
-				var beat, q_beat;
+					var beat_ticks = Math.floor((480 * 4) / displaySettings.timesig_den);
+					var measure_ticks = displaySettings.timesig_num * beat_ticks;
+					var q_beat_ticks = Math.floor(beat_ticks / 4);
+					var beat, q_beat;
 
-				var measure = Math.floor(ticks / measure_ticks);
-				if(measure < displaySettings.maxmeasures){
-					ticks = ticks % measure_ticks;
+					var measure = Math.floor(ticks / measure_ticks);
+					if(measure < displaySettings.maxmeasures){
+						ticks = ticks % measure_ticks;
 
-					beat = Math.floor(ticks / beat_ticks);
-					ticks = ticks % beat_ticks;
+						beat = Math.floor(ticks / beat_ticks);
+						ticks = ticks % beat_ticks;
 
-					q_beat = Math.floor(ticks / q_beat_ticks);
-					ticks = ticks % q_beat_ticks;
+						q_beat = Math.floor(ticks / q_beat_ticks);
+						ticks = ticks % q_beat_ticks;
 
-					ticks = Math.floor(ticks);
-				} else {
-					beat = 0;
-					q_beat = 0;
-					ticks = 0;
-				}
+						ticks = Math.floor(ticks);
+					} else {
+						beat = 0;
+						q_beat = 0;
+						ticks = 0;
+					}
 
-				// In most composing software, the song starts at  1.1.1.0, not 0.0.0.0
-				var timeEvent = new CustomEvent("denoto-setcurrenttime", {"detail": {"measure": measure + 1, "beat": beat + 1, "quarter_beat": q_beat + 1, "tick": ticks}});
-				document.dispatchEvent(timeEvent);
+					// In most composing software, the song starts at  1.1.1.0, not 0.0.0.0
+					var timeEvent = new CustomEvent("denoto-setcurrenttime", {"detail": {"measure": measure + 1, "beat": beat + 1, "quarter_beat": q_beat + 1, "tick": ticks}});
+					document.dispatchEvent(timeEvent);
 
-				//uif(playing)
-				window.requestAnimationFrame(render);
+				}, 1000/45);
   		}
 
 			function setHeights(height){

--- a/app/assets/templates/pianoroll.html.erb
+++ b/app/assets/templates/pianoroll.html.erb
@@ -217,7 +217,13 @@
 	<div id="instrumentproperties">
 		<div id="instrumentpropertiesHeader"><h3>Instrument Properties</h3></div>
 
-		<p> Target Instrument
+		<p> 
+			Insert Velocity
+			<input id="insert_velocity" type="number" value="50" min="0" max="100">
+		</p>
+
+		<p>
+			Target Instrument
 			<select id="instrument_select">
 				<option value="0">0</option>
 				<option value="1">1</option>
@@ -320,12 +326,12 @@
 <link rel="import" href="<%= asset_path("editabletext.html")%>">
 
 <script>
-    (function(){
-    	// keep track of display settings like ticks per pixel (AKA zoom level), and whether to show measure guides
-    	var displaySettings = {TPP: 4, showguides: true, loopEnabled: false, quantization: (1920 / 16), timesig_num: 4, timesig_den: 4, snapto: true, endmarkerticks: 7680, maxmeasures: 5};
+(function(){
+		// keep track of display settings like ticks per pixel (AKA zoom level), and whether to show measure guides
+		var displaySettings = {TPP: 4, showguides: true, loopEnabled: false, quantization: (1920 / 16), timesig_num: 4, timesig_den: 4, snapto: true, endmarkerticks: 7680, maxmeasures: 5};
 
-    	// hold the pianoroll's node when it's detached
-    	var pianorollholder;
+		// hold the pianoroll's node when it's detached
+		var pianorollholder;
 
 		// declare a persistent canvas
 		var bgCanvas, canvas;
@@ -487,8 +493,10 @@
 				ptnId = event.detail.pattern._id.toString();
 				this.ptnId = event.detail.pattern._id;
 
-				// put the current marker at the beginning of this instance of the pattern
-				rhomb.moveToPositionTicks(event.detail.start);
+				// put the current marker at the beginning of this instance of the pattern (only if not playing)
+				if (!rhomb.isPlaying()) {
+					rhomb.moveToPositionTicks(event.detail.start);
+				}	
 				displaySettings.startOffsetTicks = event.detail.start;
 
 				displaySettings.endmarkerticks = event.detail.pattern._length;
@@ -582,6 +590,14 @@
 					displaySettings.TPP = 16;
 
 				redrawEverything();
+			}
+
+			// TG WAS HERE
+			// This is kinda hacky
+			var insertVelocity = 0.5;
+			root.getElementById("insert_velocity").onchange = function(){
+				insertVelocity = root.getElementById("insert_velocity").value / 100;
+				console.log("[Pianoroll] - setting insert velocity to " + insertVelocity);
 			}
 
 			root.getElementById("instrument_select").onchange = function(){
@@ -1723,6 +1739,7 @@
 					footerContext.drawImage(canvas, 0, 0);
 
 				} else if(mode === 'draw') {
+					preview.velocity = insertVelocity;
 					var myNote = noteset.AddNote(preview);
 					drawNote(context, myNote, displaySettings);
 

--- a/app/assets/templates/trackview.html.erb
+++ b/app/assets/templates/trackview.html.erb
@@ -757,19 +757,24 @@
 			}
 
 			this.handleZoomIn = function(){
-				displaySettings.TPP = displaySettings.TPP / 2;
-				if(displaySettings.TPP < 1)
-					displaySettings.TPP = 1;
-
-				redrawEverything();
+				displaySettings.TPP = displaySettings.TPP / 4;
+				if(displaySettings.TPP < 4) {
+					displaySettings.TPP = 4;
+				}
+				else {
+					redrawEverything();
+				}
 			}
 
 			this.handleZoomOut = function(){
 				displaySettings.TPP = displaySettings.TPP * 2;
 				if(displaySettings.TPP > 16)
+				{
 					displaySettings.TPP = 16;
-
-				redrawEverything();
+				}
+				else {
+					redrawEverything();
+				}
 			}
 
 			function getMousePosition(element){
@@ -784,49 +789,51 @@
 			}
 
 			function render(){
-				// draw the time marker on the overlay
-				redrawOverlay(root, displaySettings);
-				var ticks = rhomb.seconds2Ticks(rhomb.getPosition());
-				drawTimeMarker(overlayContext, ticks, overlayCanvas.getAttribute("height"), displaySettings);
+ 				setTimeout(function() {
+	        window.requestAnimationFrame(render);
 
-				// The tick value can become negative when playback loops around
-				// This is to 'correct' the tick value so that the time display is more accurate
-				if (ticks < 0) {
-					ticks = rhomb.getLoopEnd() + ticks;
-				}
+					// draw the time marker on the overlay
+					redrawOverlay(root, displaySettings);
+					var ticks = rhomb.seconds2Ticks(rhomb.getPosition());
+					drawTimeMarker(overlayContext, ticks, overlayCanvas.getAttribute("height"), displaySettings);
 
-				var beat_ticks = Math.floor((480 * 4) / displaySettings.timesig_den);
-				var measure_ticks = displaySettings.timesig_num * beat_ticks;
-				var q_beat_ticks = Math.floor(beat_ticks / 4);
-				var beat, q_beat;
+					// The tick value can become negative when playback loops around
+					// This is to 'correct' the tick value so that the time display is more accurate
+					if (ticks < 0) {
+						ticks = rhomb.getLoopEnd() + ticks;
+					}
 
-				var bpm = rhomb.getBpm();
-				var bpmEvent = new CustomEvent("denoto-setbpm", {"detail": {"bpm" : bpm}});
-				document.dispatchEvent(bpmEvent);
+					var beat_ticks = Math.floor((480 * 4) / displaySettings.timesig_den);
+					var measure_ticks = displaySettings.timesig_num * beat_ticks;
+					var q_beat_ticks = Math.floor(beat_ticks / 4);
+					var beat, q_beat;
 
-				var measure = Math.floor(ticks / measure_ticks);
-				if(measure < displaySettings.maxmeasures){
-					ticks = ticks % measure_ticks;
+					var bpm = rhomb.getBpm();
+					var bpmEvent = new CustomEvent("denoto-setbpm", {"detail": {"bpm" : bpm}});
+					document.dispatchEvent(bpmEvent);
 
-					beat = Math.floor(ticks / beat_ticks);
-					ticks = ticks % beat_ticks;
+					var measure = Math.floor(ticks / measure_ticks);
+					if(measure < displaySettings.maxmeasures){
+						ticks = ticks % measure_ticks;
 
-					q_beat = Math.floor(ticks / q_beat_ticks);
-					ticks = ticks % q_beat_ticks;
+						beat = Math.floor(ticks / beat_ticks);
+						ticks = ticks % beat_ticks;
 
-					ticks = Math.floor(ticks);
-				} else {
-					beat = 0;
-					q_beat = 0;
-					ticks = 0;
-				}
+						q_beat = Math.floor(ticks / q_beat_ticks);
+						ticks = ticks % q_beat_ticks;
 
-				// In most composing software, the song starts at  1.1.1.0, not 0.0.0.0
-				var timeEvent = new CustomEvent("denoto-setcurrenttime", {"detail": {"measure": measure + 1, "beat": beat + 1, "quarter_beat": q_beat + 1, "tick": ticks}});
-				document.dispatchEvent(timeEvent);
+						ticks = Math.floor(ticks);
+					} else {
+						beat = 0;
+						q_beat = 0;
+						ticks = 0;
+					}
 
-				//if(playing)
-				window.requestAnimationFrame(render);
+					// In most composing software, the song starts at  1.1.1.0, not 0.0.0.0
+					var timeEvent = new CustomEvent("denoto-setcurrenttime", {"detail": {"measure": measure + 1, "beat": beat + 1, "quarter_beat": q_beat + 1, "tick": ticks}});
+					document.dispatchEvent(timeEvent);
+
+				}, 1000/45);
   		}
 
 			function setHeights(height){

--- a/app/views/tracks/edit.html.erb
+++ b/app/views/tracks/edit.html.erb
@@ -13,5 +13,11 @@
   var bpm = rhomb.getBpm();
   var bpmEvent = new CustomEvent("denoto-setbpm", {"detail": {"bpm" : bpm}});
   document.dispatchEvent(bpmEvent);
+
+  // initialize the loop bar
+  var loopEvent = new CustomEvent("denoto-updateloopstart", {"detail": {"start": rhomb.getLoopStart()}});
+  document.dispatchEvent(loopEvent);
+  loopEvent = new CustomEvent("denoto-updateloopend", {"detail": {"end": rhomb.getLoopEnd()}});
+  document.dispatchEvent(loopEvent);
 })();
 </script>


### PR DESCRIPTION
I have added provisional support for note velocity. In the pianoroll, there is now a control for selecting the velocity of inserted notes (in the range 0-100, which gets scaled to 0.0-1.0 behind the scenes). I haven't added velocity to the 'Note Properties' panel in the pianoroll, because I couldn't quite figure out the preview note thing. 

The instruments don't currently respond to different velocities, for reasons that remain mysterious. But ultimately this will allow the user to control the volume/dynamics of individual notes.

In a previous commit, TW made it so that the playback cursor moves to the start of a playlist item when its root pattern is opened in the pianoroll, which is a great feature. I disabled this feature during when the song is playing to prevent jarring jumps in playback position.

P.S.
I just wrapped the render functions in a timeout to try to control FPS.
