### PR TITLE
Pattern editor fixes

### DIFF
--- a/app/assets/javascripts/noteset.js
+++ b/app/assets/javascripts/noteset.js
@@ -14,7 +14,7 @@ function NoteSet(count, id){
 
 // inserts an existing rhombus note to the noteset
 NoteSet.prototype.InsertNote = function(rnote, color){
-	var note = {"keyValue": -1 * (rnote._pitch - 1 - this.lanes.length), "tickstart": rnote._start, "tickduration": rnote._length, "rnote": rnote, "color": color};
+	var note = {"keyValue": -1 * (rnote._pitch + 1 - this.lanes.length), "tickstart": rnote._start, "tickduration": rnote._length, "rnote": rnote, "color": color};
 
 	// insert the note into the lane
 	var lane = this.lanes[note.keyValue];
@@ -33,7 +33,6 @@ NoteSet.prototype.AddNote = function(note){
 
 	if(typeof note.ID === 'undefined'){
 		// assign a new ID to the note
-		// TODO: fix temporary keyValue shift
 		var rnote = new rhomb.Note(this.lanes.length - 1 - note.keyValue, note.tickstart, note.tickduration, +note.velocity);
 		note.rnote = rnote;
 		note.ID = rnote._id;
@@ -43,7 +42,7 @@ NoteSet.prototype.AddNote = function(note){
 	var lane = this.lanes[note.keyValue];
 	lane.insertOne(note);
 
-	console.log("[NoteSet] Writing note ID " + note.rnote._id + " at tick " + note.rnote.getStart() + ", length " + note.rnote.getLength());
+	console.log("[NoteSet] Writing note ID " + note.rnote._id + " at tick " + note.rnote.getStart() + ", length " + note.rnote.getLength() + ", pitch " + note.rnote._pitch);
   rhomb.Edit.insertNote(note.rnote, this.id);
 
 	// return the added note (with any necessary adjustments)
@@ -263,7 +262,7 @@ NoteSet.prototype.UpdateRhombNote = function(note) {
 			note.tickduration = rnote.getLength();
 		}
 
-		console.log("[NoteSet] Updating note ID " + rnote._id + " at tick " + rnote.getStart() + ", length " + rnote.getLength());
+		console.log("[NoteSet] Updating note ID " + rnote._id + " at tick " + rnote.getStart() + ", length " + rnote.getLength() + ", pitch " + rnote._pitch);
 	}
 }
 

--- a/app/assets/templates/keyboard.html.erb
+++ b/app/assets/templates/keyboard.html.erb
@@ -78,7 +78,7 @@
         //key.setAttribute('style', "position: absolute; left: 0px; top: " + (i + heightoffset) * 19.7 + "px; z-index: 1;");
         }
 
-        key.setAttribute('value', max - i);
+        key.setAttribute('value', max - 1 - i);
         that.shadowRoot.getElementById('keyboard').appendChild(key);
       }
 


### PR DESCRIPTION
An issue where the keyboard note sound had a pitch of 1 less than the lane notes has been corrected, and a bug where saving notes into the pattern editor, and then closing -> reopening the pattern would cause all previously-written notes to shift down two lanes.
