### PR TITLE
Tick-based note properties represented in clock form, measure numbering added

### DIFF
--- a/app/assets/javascripts/drawing.js
+++ b/app/assets/javascripts/drawing.js
@@ -127,7 +127,7 @@ function drawCanvas(context, width, height, displaySettings){
 		if(on && times !== 0 && times !== 7 && times !== 12){
 			context.beginPath()
 			context.rect(0, i, width, 23);
-			context.linewidth = 5;
+			context.lineWidth = 1;
 			context.strokeStyle = "#000000";
 			context.fillStyle = "#BBBBBB";
 			context.fill();
@@ -140,7 +140,7 @@ function drawCanvas(context, width, height, displaySettings){
 			context.beginPath()
 			context.moveTo(0, i);
 			context.lineTo(width, i);
-			context.linewidth = 2;
+			context.lineWidth = 1;
 			context.strokeStyle = "#777777";
 			context.fillStyle = "#BBBBBB";
 			context.fill();
@@ -163,14 +163,16 @@ function drawCanvas(context, width, height, displaySettings){
 
 		for(var i = 0.0; i < width; i += incr){
 			context.beginPath();
-			context.linewidth = 5;
 			context.moveTo(i, 0);
 			context.lineTo(i, height);
 			if(i % meas_disp === 0.0){
-				context.strokeStyle = "#2222AA";
+				context.lineWidth = 2;
+				context.strokeStyle = "#000000";
 			} else if(i % beat_disp === 0.0){
+				context.lineWidth = 1;
 				context.strokeStyle = "#000000";
 			} else {
+				context.lineWidth = 1;
 				context.strokeStyle = "#666666";
 			}
 			context.fill();
@@ -238,7 +240,7 @@ function drawTracksCanvas(context, width, height, displaySettings){
 		context.beginPath()
 		context.moveTo(0, i);
 		context.lineTo(width, i);
-		context.linewidth = 2;
+		context.lineWidth = 1;
 		context.strokeStyle = "#777777";
 		context.fillStyle = "#BBBBBB";
 		context.fill();
@@ -256,14 +258,16 @@ function drawTracksCanvas(context, width, height, displaySettings){
 
 		for(var i = 0.0; i < width; i += incr){
 			context.beginPath();
-			context.linewidth = 5;
 			context.moveTo(i, 0);
 			context.lineTo(i, height);
 			if(i % meas_disp === 0.0){
-				context.strokeStyle = "#2222AA";
+				context.lineWidth = 2;
+				context.strokeStyle = "#000000";
 			} else if(i % beat_disp === 0.0){
+				context.lineWidth = 1;
 				context.strokeStyle = "#000000";
 			} else {
+				context.lineWidth = 1;
 				context.strokeStyle = "#666666";
 			}
 			context.fill();
@@ -350,20 +354,28 @@ function drawMeasureBar(root, displaySettings){
 	for(var i = 0.0; i < width; i += incr){
 		context.beginPath();
 		if(i % meas_disp === 0.0){
-			context.linewidth = 8;
-			context.strokeStyle = "#2222AA";
+			context.lineWidth = 2;
+			context.strokeStyle = "#000000";
 			context.moveTo(i, 0);
 		} else	if(i % beat_disp === 0.0){
-			context.linewidth = 8;
+			context.lineWidth = 1;
 			context.strokeStyle = "#000000";
 			context.moveTo(i, 0);
 		} else {
-			context.linewidth = 5;
+			context.lineWidth = 1;
 			context.strokeStyle = "#666666";
 			context.moveTo(i, height / 2);
 		}
 		context.lineTo(i, height);
 		context.stroke();
+
+		if(i % meas_disp === 0.0){
+			// draw the measure caption
+			var caption = Math.floor(i / meas_disp) + 1;
+			context.fillStyle = "#000000";
+			context.font="11px Arial";
+			context.fillText(caption, (i + 3), 12);
+		}
 	}
 
 

--- a/app/assets/templates/editableclock.html.erb
+++ b/app/assets/templates/editableclock.html.erb
@@ -1,0 +1,91 @@
+<template>
+  <div id="container">
+    <span id="caption"></span> <denoto-editabletext id="clock_measure" type="tinytext" value="0" suffix="."></denoto-editabletext>
+    <denoto-editabletext id="clock_beat" type="tinytext" value="0" suffix="."></denoto-editabletext>
+    <denoto-editabletext id="clock_q_beat" type="tinytext" value="0" suffix="."></denoto-editabletext>
+    <denoto-editabletext id="clock_ticks" type="shortertext" value="0"></denoto-editabletext>
+  </div>
+  <style>
+    #container{
+      display: inline-block;
+    }
+  </style>
+</template>
+<script src="<%= asset_path("time.js")%>"></script>
+<script>
+  (function(){
+    // get the template for this element
+    var template = document.currentScript.ownerDocument.querySelector('template');
+
+    // copy a prototype from HTMLElement
+    var editableclockPrototype = Object.create(HTMLElement.prototype);
+
+    // specify the created callback ("constructor")
+    editableclockPrototype.createdCallback = function(){
+      var that = this;
+
+      var root = this.createShadowRoot();
+      root.appendChild(document.importNode(template.content, true));
+
+      var clock_measure = root.getElementById('clock_measure');
+      var clock_beat = root.getElementById('clock_beat');
+      var clock_q_beat = root.getElementById('clock_q_beat');
+      var clock_ticks = root.getElementById('clock_ticks');
+      var container = root.getElementById('container');
+
+      this.clock = new Clock(clock_measure, clock_beat, clock_q_beat, clock_ticks);
+
+      // handle default value settings
+      var val = this.getAttribute("value");
+      if(typeof val !== 'undefined'){
+        this.clock.setTicks(val);
+        this.setAttribute("value", parseInt(val));
+      } else {
+        this.clock.setTicks(0);
+      }
+      
+      var caption = this.getAttribute("caption");
+      if(typeof caption !== 'undefined'){
+        root.getElementById('caption').innerText = caption;
+      }
+
+      var width = this.getAttribute("width");
+      if(typeof width !== 'undefined')
+        container.style.width = width + "px";
+
+      // apply the styles assigned to the component to the inner text
+      caption.style = root.host.style;
+      clock_measure.style = root.host.style;
+      clock_beat.style = root.host.style;
+      clock_q_beat.style = root.host.style;
+      clock_ticks.style = root.host.style;
+      container.style = root.host.style;
+
+      // prevent cursor from flickering
+      container.addEventListener("mouseover", function(){
+        event.preventDefault();
+      });
+
+      root.addEventListener('editabletext-changed', function(){
+        that.value = that.clock.getTicks();
+        that.setAttribute("value", that.clock.getTicks());
+      });
+    };
+
+    // specify the "an attribute has changed" callback
+    editableclockPrototype.attributeChangedCallback = function(attrName, oldVal, newVal){
+      if(attrName === "value"){
+        this.value = newVal;
+        this.clock.setTicks(parseInt(newVal));
+      } else if(attrName === "width"){
+        if(typeof newVal !== 'undefined')
+          this.shadowRoot.querySelector("#container").style.width = newVal + "px";
+        else
+          this.shadowRoot.querySelector("#container").style.width = "";
+      }
+    };
+
+    // register the element
+    var editableclock = document.registerElement('denoto-editableclock', {prototype: editableclockPrototype});
+  })();
+</script>

--- a/app/assets/templates/pianoroll.html.erb
+++ b/app/assets/templates/pianoroll.html.erb
@@ -214,17 +214,15 @@
 	</style>
 	<div id="noteproperties">
 		<div id="notepropertiesHeader"><h3>Note Properties</h3></div>
-		<!--<p>Start <input type="text" id="note_start"></input></p>
-		<p>Length <input type="text" id="note_length"></input></p>-->
-		<p>Start: <denoto-editabletext type="shorttext" id="note_start" width="50"></denoto-editabletext></p>
-    <p>Length: <denoto-editabletext type="shorttext" id="note_length" width="50"></denoto-editabletext></p>
-    <p>Velocity: <denoto-editabletext type="shorttext" id="note_velocity" width="50"></denoto-editabletext></p>
+		<p><denoto-editableclock type="shorttext" id="note_start" caption="Start: "></denoto-editableclock></p>
+		<p><denoto-editableclock type="shorttext" id="note_length" caption="Length: "></denoto-editableclock></p>
+    <p>Velocity: <denoto-editabletext type="shorttext" id="note_velocity"></denoto-editabletext></p>
 		<p>Auto-adjust <input type="checkbox" id="note_autoadjust" checked></p>
 	</div>
 	<div id="groupproperties">
 		<div id="grouppropertiesHeader"><h3>Group Properties</h3></div>
-		<p>Start: <denoto-editabletext type="text" id="group_start" width="50"></denoto-editabletext></p>
-		<p>Length: <denoto-editabletext type="text" id="group_length" width="50"></denoto-editabletext></p>
+		<p><denoto-editableclock type="shorttext" id="group_start" caption="Start: "></denoto-editableclock></p>
+		<p><denoto-editableclock type="shorttext" id="group_length" caption="Length: "></denoto-editableclock></p>
 		<p>Auto-adjust <input type="checkbox" id="group_autoadjust" checked></p>
 	</div>
 	<div id="instrumentproperties">

--- a/app/assets/templates/trackview.html.erb
+++ b/app/assets/templates/trackview.html.erb
@@ -246,14 +246,14 @@
 	</style>
 	<div id="patternproperties">
 		<div id="patternpropertiesHeader"><h3>Pattern Properties</h3></div>
-		<p>Start: <denoto-editabletext type="shorttext" id="pattern_start" width="50"></denoto-editabletext></p>
-		<p>Length: <denoto-editabletext type="shorttext" id="pattern_length" width="50"></denoto-editabletext></p>
+		<p><denoto-editableclock type="shorttext" id="pattern_start" caption="Start: "></denoto-editableclock></p>
+		<p><denoto-editableclock type="shorttext" id="pattern_length" caption="Length: "></denoto-editableclock></p>
 		<p>Auto-adjust <input type="checkbox" id="pattern_autoadjust" checked></p>
 	</div>
 	<div id="groupproperties">
 		<div id="grouppropertiesHeader"><h3>Group Properties</h3></div>
-		<p>Start: <denoto-editabletext type="text" id="group_start" width="50"></denoto-editabletext></p>
-		<p>Length: <denoto-editabletext type="text" id="group_length" width="50"></denoto-editabletext></p>
+		<p><denoto-editableclock type="shorttext" id="group_start" caption="Start: "></denoto-editableclock></p>
+		<p><denoto-editableclock type="shorttext" id="group_length" caption="Length: "></denoto-editableclock></p>
 		<p>Auto-adjust <input type="checkbox" id="group_autoadjust" checked></p>
 	</div>
 	<div id="patternlist">
@@ -296,6 +296,7 @@
 <script src="<%= asset_path("time.js")%>"></script>
 <link rel="import" href="<%= asset_path("tracklist.html")%>">
 <link rel="import" href="<%= asset_path("editabletext.html")%>">
+<link rel="import" href="<%= asset_path("editableclock.html")%>">
 <link rel="import" href="<%= asset_path("pattern.html")%>">
 
 <script>
@@ -998,7 +999,6 @@
 			}
 
 			this.handleSetEndTime = function(){
-				console.log("[TrackView] handleSetEndTime");
 				displaySettings.endmarkerticks = event.detail.ticks;
 
 				render();
@@ -1797,23 +1797,16 @@
 			function handlePatternKeyUp()
 			{
 				if(event.keyCode == 13){
-					// TODO: sanitize inputs
-					// keep a backup of the unchanged currently-selected pattern in order to erase it if needed
-					var backup = new Pattern(trackset.currentPattern);
-					
-					// try to change the parameters of the currently-selected pattern
-					if(trackset.TrySetPattern({"_start": parseInt(pattern_start.value), "_length": parseInt(pattern_length.value), autoadjust: pattern_autoadjust.checked})){
-						// change succeeded, erase old pattern and draw the new one
-						erasePattern(context, backup, displaySettings);
-						drawSelectedPattern(context, trackset.currentPattern, displaySettings);
-						
-						// update the pattern in rhombus
-						trackset.UpdateRhombPattern(trackset.currentPattern);
+					// update the pattern in rhombus
+					trackset.currentPattern.setLength(pattern_length.getAttribute("value"));
+					trackset.currentPattern.setStart(pattern_start.getAttribute("value"));
 
-						// update the pattern properties pane with new values
-						pattern_start.setAttribute("value", trackset.currentPattern.getStart());
-						pattern_length.setAttribute("value", trackset.currentPattern.getLength());
-					}
+					// erase old pattern and draw the new one
+					redrawTracks();
+
+					// update the pattern properties pane with new values
+					pattern_start.setAttribute("value", trackset.currentPattern.getStart());
+					pattern_length.setAttribute("value", trackset.currentPattern.getLength());
 				}
 			}
 


### PR DESCRIPTION
A new component (editableclock) has been added, and is used to replace editabletext fields intended to contain ticks, and displays as a musical clock. The tick-based property fields in the pianoroll and trackview have been replaced with this.
