### PR TITLE
Trackview and Pianoroll fixes

### DIFF
--- a/app/assets/templates/endmarker.html.erb
+++ b/app/assets/templates/endmarker.html.erb
@@ -42,6 +42,9 @@
 
 			document.addEventListener('denoto-setendtime', function(){
 				max.setTicks(event.detail.ticks);
+				if(typeof rhomb !== 'undefined'){
+					rhomb.getSong().setLength(event.detail.ticks);
+				}
 			});
 
 			max_measure.addEventListener('keyup', handleKeyUp);

--- a/app/assets/templates/endmarker.html.erb
+++ b/app/assets/templates/endmarker.html.erb
@@ -57,7 +57,7 @@
 					// TODO: sanitize inputs
 					var input = parseInt(event.srcElement.value);
 					var lastmeasure = ticks_to_musical_time(max.getTicks()).measure + 1;
-					var timeEvent = new CustomEvent("denoto-setendtime", {"detail": {"ticks": max.getTicks(), "lastmeasure": lastmeasure} });
+					var timeEvent = new CustomEvent("denoto-setendtime", {"detail": {"ticks": max.getTicks(), "autoresize": true, "scroll": false} });
 					document.dispatchEvent(timeEvent);
 
 					max.setTicks(max.getTicks());

--- a/app/assets/templates/endmarker.html.erb
+++ b/app/assets/templates/endmarker.html.erb
@@ -56,7 +56,8 @@
 				if(event.keyCode == 13){
 					// TODO: sanitize inputs
 					var input = parseInt(event.srcElement.value);
-					var timeEvent = new CustomEvent("denoto-setendtime", {"detail": {"ticks": max.getTicks()} });
+					var lastmeasure = ticks_to_musical_time(max.getTicks()).measure + 1;
+					var timeEvent = new CustomEvent("denoto-setendtime", {"detail": {"ticks": max.getTicks(), "lastmeasure": lastmeasure} });
 					document.dispatchEvent(timeEvent);
 
 					max.setTicks(max.getTicks());

--- a/app/assets/templates/pianoroll.html.erb
+++ b/app/assets/templates/pianoroll.html.erb
@@ -593,7 +593,7 @@
 
 				displaySettings.endmarkerticks = event.detail.pattern._length;
 
-				var timeEvent = new CustomEvent('denoto-setendtime', {"detail": {"ticks": displaySettings.endmarkerticks, "autoresize": true}});
+				var timeEvent = new CustomEvent('denoto-setendtime', {"detail": {"ticks": displaySettings.endmarkerticks, "autoresize": true, "scroll": false}});
 				document.dispatchEvent(timeEvent);
 
 				// clear the noteset
@@ -1199,8 +1199,14 @@
 				displaySettings.endmarkerticks = event.detail.ticks;
 				
 				if(typeof event.detail.autoresize !== 'undefined' && event.detail.autoresize){
+					var temp = displaySettings.maxmeasures;
+
 					displaySettings.maxmeasures = ticks_to_musical_time(event.detail.ticks).measure + 1;
 					redrawEverything();
+
+					// if the song was lengthened, scroll to the right
+					if(temp < displaySettings.maxmeasures && event.detail.scroll === true)
+						pianoroll.scrollLeft = 999999999;
 				} else {
 					render();
 				}
@@ -1480,7 +1486,7 @@
 					drawEndmarker(root, displaySettings, previewMarker * displaySettings.TPP);
 					displaySettings.endmarkerticks = ticks;
 
-					var timeEvent = new CustomEvent("denoto-setendtime", {"detail": {"ticks": ticks, "autoresize": false}});
+					var timeEvent = new CustomEvent("denoto-setendtime", {"detail": {"ticks": ticks, "autoresize": false, "scroll": false}});
 					document.dispatchEvent(timeEvent);
 				}
 			}
@@ -1506,7 +1512,7 @@
 				var pattern = rhomb.getSong().getPatterns()[this.ptnId];
 				pattern.setLength(ticks);
 
-				var timeEvent = new CustomEvent("denoto-setendtime", {"detail": {"ticks": ticks, "autoresize": true}});
+				var timeEvent = new CustomEvent("denoto-setendtime", {"detail": {"ticks": ticks, "autoresize": true, "scroll": true}});
 				document.dispatchEvent(timeEvent);
 
 				// unset mouse button for mousemove events

--- a/app/assets/templates/pianoroll.html.erb
+++ b/app/assets/templates/pianoroll.html.erb
@@ -593,7 +593,7 @@
 
 				displaySettings.endmarkerticks = event.detail.pattern._length;
 
-				var timeEvent = new CustomEvent('denoto-setendtime', {detail: {ticks: displaySettings.endmarkerticks}});
+				var timeEvent = new CustomEvent('denoto-setendtime', {"detail": {"ticks": displaySettings.endmarkerticks, "autoresize": true}});
 				document.dispatchEvent(timeEvent);
 
 				// clear the noteset
@@ -1197,35 +1197,20 @@
 
 			this.handleSetEndTime = function(){
 				displaySettings.endmarkerticks = event.detail.ticks;
-
-				render();
+				
+				if(typeof event.detail.autoresize !== 'undefined' && event.detail.autoresize){
+					displaySettings.maxmeasures = ticks_to_musical_time(event.detail.ticks).measure + 1;
+					redrawEverything();
+				} else {
+					render();
+				}
 			}
 
 			this.handleResetEndTime = function(){
-				/*var timeEvent = new CustomEvent('denoto-setendtime', {detail: {ticks: displaySettings.endmarkerticks}});
+				/*var timeEvent = new CustomEvent('denoto-setendtime', {detail: {ticks: displaySettings.endmarkerticks, "autoresize": true}});
 				document.dispatchEvent(timeEvent);
 
 				render();*/
-			}
-
-			this.handleSetDuration = function(){
-				var beat = Math.floor((480 * 4) / displaySettings.timesig_den);
-				var measure = displaySettings.timesig_num * beat;
-
-				displaySettings.maxmeasures = event.detail.total_measures;
-
-				if(displaySettings.maxmeasures < (displaySettings.endmarkerticks / measure)){
-					var newend = displaySettings.maxmeasures * measure;
-					displaySettings.endmarkerticks = newend;
-
-					measure = displaySettings.maxmeasures;
-					var ticks = musical_time_to_ticks({"measure": measure, "beat": 0, "q_beat": 0, "ticks": 0});
-
-					var timeEvent = new CustomEvent("denoto-setendtime", {"detail": {"ticks": ticks}});
-					document.dispatchEvent(timeEvent);
-				}
-
-				redrawEverything();
 			}
 
 			function setupTopbarEvents(){
@@ -1495,7 +1480,7 @@
 					drawEndmarker(root, displaySettings, previewMarker * displaySettings.TPP);
 					displaySettings.endmarkerticks = ticks;
 
-					var timeEvent = new CustomEvent("denoto-setendtime", {"detail": {"ticks": ticks}});
+					var timeEvent = new CustomEvent("denoto-setendtime", {"detail": {"ticks": ticks, "autoresize": false}});
 					document.dispatchEvent(timeEvent);
 				}
 			}
@@ -1521,7 +1506,7 @@
 				var pattern = rhomb.getSong().getPatterns()[this.ptnId];
 				pattern.setLength(ticks);
 
-				var timeEvent = new CustomEvent("denoto-setendtime", {"detail": {"ticks": ticks}});
+				var timeEvent = new CustomEvent("denoto-setendtime", {"detail": {"ticks": ticks, "autoresize": true}});
 				document.dispatchEvent(timeEvent);
 
 				// unset mouse button for mousemove events
@@ -2488,7 +2473,6 @@
 			document.addEventListener('denoto-zoomout', this.handleZoomOut);
 			document.addEventListener('denoto-setendtime', this.handleSetEndTime);
 			document.addEventListener('denoto-resetendtime', this.handleResetEndTime);
-			document.addEventListener('denoto-setduration', this.handleSetDuration);
 			document.addEventListener('denoto-resizescrollbar', this.resizeScrollbar);
 			document.addEventListener('denoto-setloopsettings', this.setLoopsettings);
 			//redrawEverything();
@@ -2512,7 +2496,6 @@
 			document.removeEventListener('denoto-zoomout', this.handleZoomOut);
 			document.removeEventListener('denoto-setendtime', this.handleSetEndTime);
 			document.removeEventListener('denoto-resetendtime', this.handleResetEndTime);
-			document.removeEventListener('denoto-setduration', this.handleSetDuration);
 		};
 
 		// register the element

--- a/app/assets/templates/tracklist.html.erb
+++ b/app/assets/templates/tracklist.html.erb
@@ -185,7 +185,8 @@
     }
 
     document.addEventListener('denoto-setwidths', function(){
-      root.getElementById("rowcover").style.width = (parseInt(root.host.ownerDocument.body.clientWidth) - 250) + "px";
+      //root.getElementById("rowcover").style.width = (parseInt(root.host.ownerDocument.body.clientWidth) - 250) + "px";
+      root.getElementById("rowcover").style.width = event.detail.width + "px";
     });
 
     // helper function to create empty tracks in the shadow div

--- a/app/assets/templates/trackview.html.erb
+++ b/app/assets/templates/trackview.html.erb
@@ -763,6 +763,12 @@
 						handleMousedown();
 					}
 					else {
+						// snap to guides if enabled
+						if(displaySettings.snapto){
+							var adjustment = displaySettings.quantization / displaySettings.TPP;
+							mouse.x = Math.floor(mouse.x / adjustment) * adjustment;
+						}
+
 						event.preventDefault();
 						rhomb.moveToPositionTicks(mouse.x * displaySettings.TPP);
 						var posEvent = new CustomEvent("denoto-updatestartpos");

--- a/app/assets/templates/trackview.html.erb
+++ b/app/assets/templates/trackview.html.erb
@@ -462,7 +462,7 @@
 					document.dispatchEvent(trackEvent);
 				}
 
-				var endEvent = new CustomEvent('denoto-setendtime', {"detail": {"ticks": rhomb.getSong().getLength(), "autoresize": true}});
+				var endEvent = new CustomEvent('denoto-setendtime', {"detail": {"ticks": rhomb.getSong().getLength(), "autoresize": true, "scroll": false}});
 				document.dispatchEvent(endEvent);
 
 				// draw the added patterns
@@ -1011,15 +1011,21 @@
 				displaySettings.endmarkerticks = event.detail.ticks;
 				
 				if(typeof event.detail.autoresize !== 'undefined' && event.detail.autoresize){
+					var temp = displaySettings.maxmeasures;
+
 					displaySettings.maxmeasures = ticks_to_musical_time(event.detail.ticks).measure + 1;
 					redrawEverything();
+
+					// if the song was lengthened, scroll to the right
+					if(temp < displaySettings.maxmeasures && event.detail.scroll === true)
+						trackview.scrollLeft = 999999999;
 				} else {
 					render();
 				}
 			}
 
 			this.handleResetEndTime = function(){
-				var timeEvent = new CustomEvent('denoto-setendtime', {"detail": {"ticks": displaySettings.endmarkerticks, "autoresize": true}});
+				var timeEvent = new CustomEvent('denoto-setendtime', {"detail": {"ticks": displaySettings.endmarkerticks, "autoresize": true, "scroll": false}});
 				document.dispatchEvent(timeEvent);
 
 				render();
@@ -1205,7 +1211,7 @@
 					drawEndmarker(root, displaySettings, previewMarker * displaySettings.TPP);
 					displaySettings.endmarkerticks = ticks;
 
-					var timeEvent = new CustomEvent("denoto-setendtime", {"detail": {"ticks": ticks, "autoresize": false}});
+					var timeEvent = new CustomEvent("denoto-setendtime", {"detail": {"ticks": ticks, "autoresize": false, "scroll": false}});
 					document.dispatchEvent(timeEvent);
 				}
 			}
@@ -1227,7 +1233,7 @@
 
 				displaySettings.endmarkerticks = ticks;
 
-				var timeEvent = new CustomEvent("denoto-setendtime", {"detail": {"ticks": ticks, "autoresize": true}});
+				var timeEvent = new CustomEvent("denoto-setendtime", {"detail": {"ticks": ticks, "autoresize": true, "scroll": true}});
 				document.dispatchEvent(timeEvent);
 
 				// unset mouse button for mousemove events

--- a/app/assets/templates/trackview.html.erb
+++ b/app/assets/templates/trackview.html.erb
@@ -1454,7 +1454,9 @@
 						var x = mouse.x - (trackset.currentPattern.getStart() / displaySettings.TPP);
 
 						trackset.currentPattern.setStart(Xoffset * displaySettings.TPP);
-						trackset.currentPattern.setLength(x * displaySettings.TPP);
+
+						if(x !== 0)
+							trackset.currentPattern.setLength(x * displaySettings.TPP);
 					}
 				}
 				else
@@ -1670,7 +1672,12 @@
 				} else if(mode === 'draw') {
 					var id = trackset.currentPattern._ptnId;
 					var rpattern = rhomb.getSong().getPatterns()[id];
-					rpattern.setLength(trackset.currentPattern.getLength());
+
+					var length = trackset.currentPattern.getLength();
+					if(length === 0)
+						length = displaySettings.quantization;
+
+					rpattern.setLength(length);
 
 					status = undefined;
 					trackset.currentPattern = undefined;

--- a/app/assets/templates/trackview.html.erb
+++ b/app/assets/templates/trackview.html.erb
@@ -939,7 +939,7 @@
 				bgMeasurebar.setAttribute("width", width);
 				fgMeasurebar.setAttribute("width", width);
 
-				var widthEvent = new CustomEvent('denoto-setwidths', {detail: undefined});
+				var widthEvent = new CustomEvent('denoto-setwidths', {"detail": {"width": width}});
 				document.dispatchEvent(widthEvent);
 			}
 
@@ -990,7 +990,7 @@
 				window.addEventListener('resize', resizeScrollbar);
 				window.addEventListener('resize', setUIHeights);
 				window.addEventListener('resize', function(){
-					var widthEvent = new CustomEvent('denoto-setwidths', {detail: undefined});
+					var widthEvent = new CustomEvent('denoto-setwidths', {"detail": {"width": canvas.getAttribute("width")}});
 					document.dispatchEvent(widthEvent);
 				});
 

--- a/app/assets/templates/trackview.html.erb
+++ b/app/assets/templates/trackview.html.erb
@@ -462,6 +462,9 @@
 					document.dispatchEvent(trackEvent);
 				}
 
+				var endEvent = new CustomEvent('denoto-setendtime', {"detail": {"ticks": rhomb.getSong().getLength(), "autoresize": true}});
+				document.dispatchEvent(endEvent);
+
 				// draw the added patterns
 				redrawEverything();
 			});
@@ -1006,36 +1009,20 @@
 
 			this.handleSetEndTime = function(){
 				displaySettings.endmarkerticks = event.detail.ticks;
-
-				render();
-				//redrawEverything(); // if we *must* use this, try to use redrawOverlay instead, although you will need to provide its inputs
+				
+				if(typeof event.detail.autoresize !== 'undefined' && event.detail.autoresize){
+					displaySettings.maxmeasures = ticks_to_musical_time(event.detail.ticks).measure + 1;
+					redrawEverything();
+				} else {
+					render();
+				}
 			}
 
 			this.handleResetEndTime = function(){
-				var timeEvent = new CustomEvent('denoto-setendtime', {detail: {ticks: displaySettings.endmarkerticks}});
+				var timeEvent = new CustomEvent('denoto-setendtime', {"detail": {"ticks": displaySettings.endmarkerticks, "autoresize": true}});
 				document.dispatchEvent(timeEvent);
 
 				render();
-			}
-
-			this.handleSetDuration = function(){
-				var beat = Math.floor((480 * 4) / displaySettings.timesig_den);
-				var measure = displaySettings.timesig_num * beat;
-
-				displaySettings.maxmeasures = event.detail.total_measures;
-
-				if(displaySettings.maxmeasures < (displaySettings.endmarkerticks / measure)){
-					var newend = displaySettings.maxmeasures * measure;
-					displaySettings.endmarkerticks = newend;
-
-					measure = displaySettings.maxmeasures;
-					var ticks = musical_time_to_ticks({"measure": measure, "beat": 0, "q_beat": 0, "ticks": 0});
-
-					var timeEvent = new CustomEvent("denoto-setendtime", {"detail": {"ticks": ticks}});
-					document.dispatchEvent(timeEvent);
-				}
-
-				redrawEverything();
 			}
 
 			function setupTopbarEvents(){
@@ -1218,7 +1205,7 @@
 					drawEndmarker(root, displaySettings, previewMarker * displaySettings.TPP);
 					displaySettings.endmarkerticks = ticks;
 
-					var timeEvent = new CustomEvent("denoto-setendtime", {"detail": {"ticks": ticks}});
+					var timeEvent = new CustomEvent("denoto-setendtime", {"detail": {"ticks": ticks, "autoresize": false}});
 					document.dispatchEvent(timeEvent);
 				}
 			}
@@ -1240,7 +1227,7 @@
 
 				displaySettings.endmarkerticks = ticks;
 
-				var timeEvent = new CustomEvent("denoto-setendtime", {"detail": {"ticks": ticks}});
+				var timeEvent = new CustomEvent("denoto-setendtime", {"detail": {"ticks": ticks, "autoresize": true}});
 				document.dispatchEvent(timeEvent);
 
 				// unset mouse button for mousemove events
@@ -1984,7 +1971,6 @@
 			document.addEventListener('keypress', this.handleKeyPress);
 			document.addEventListener('denoto-setendtime', this.handleSetEndTime);
 			document.addEventListener('denoto-resetendtime', this.handleResetEndTime);
-			document.addEventListener('denoto-setduration', this.handleSetDuration);
 			document.addEventListener('denoto-trackviewattached', this.handleAttached);
 
 			var attachedEvent = new CustomEvent('denoto-trackviewattached', {detail: undefined});
@@ -2001,7 +1987,6 @@
 			document.removeEventListener('keypress', this.handleKeyPress);
 			document.removeEventListener('denoto-setendtime', this.handleSetEndTime);
 			document.removeEventListener('denoto-resetendtime', this.handleResetEndTime);
-			document.removeEventListener('denoto-setduration', this.handleSetDuration);
 			document.removeEventListener('denoto-trackviewattached', this.handleAttached);
 		};
 


### PR DESCRIPTION
Resizing of both components is now possible by changing the end marker. Quantization is used to set the current position with mousedown, and unselectable playlistitems are prevented by never letting length get set to 0.
