### PR TITLE
Fixed bug where user was restricted to one less track than they were supposed to be

### DIFF
--- a/app/assets/templates/tracklist.html.erb
+++ b/app/assets/templates/tracklist.html.erb
@@ -116,12 +116,12 @@
         }
 
         if (event.button === 0) {
-          var trkId = rhomb.getSong().addTrack();
-
           if (rhomb.getSong().getTracks().isFull()) {
             console.log("[TrackList] - track container is full -- not adding track");
             return;
           }
+
+          var trkId = rhomb.getSong().addTrack();
 
           console.log("[TrackList] - added track with ID " + trkId);
 


### PR DESCRIPTION
If you entered a competition with a "maximum tracks" constraint of 2, you were only able to insert 1 track in the editor. This fixes that.
