### PR TITLE
Fixed small bug in node removal (Effects Graph)

### DIFF
--- a/app/assets/templates/effectsgraph.html.erb
+++ b/app/assets/templates/effectsgraph.html.erb
@@ -984,14 +984,17 @@
       // remove the node from the nodes list
       nodes.splice(nodes.indexOf(node), 1);
 
-      // redraw the background lines
-      drawBG();
-
       // remove the node from rhombus (currently bugged in rhombus)
       if(node.isInstrument())
         rhomb.removeInstrument(node);
       else if(node.isEffect())
         rhomb.removeEffect(node);
+
+      // redraw the background lines
+      drawBG();
+
+      // remove the foreground lines
+      fgContext.clearRect(0, 0, parseInt(fgCanvas.getAttribute("width")), parseInt(fgCanvas.getAttribute("height")));
     }
 
     function rerender(){


### PR DESCRIPTION
Call to drawBG() was occurring after node's DOM element was removed from the page, but before the node was removed from the graph, causing an error.
