### PR TITLE
Translate Notes

### DIFF
--- a/app/assets/javascripts/rhombus.js
+++ b/app/assets/javascripts/rhombus.js
@@ -335,6 +335,11 @@
     return color;
   };
 
+
+  Rhombus.Util.clampMinMax = function(val, min, max) {
+    return (val < min) ? min : (val > max) ? max : val;
+  }
+
   function calculator(noteNum) {
     return Math.pow(2, (noteNum-69)/12) * 440;
   }
@@ -2831,17 +2836,17 @@
         return undefined;
       }
 
-      if (!isNumber(start) || start < 0) {
+      if (!isInteger(start) || start < 0) {
         console.log("[Rhombus] - Note start invalid: " + start);
         return undefined;
       }
 
-      if (!isNumber(length) || length < 0) {
+      if (!isInteger(length) || length < 1) {
         console.log("[Rhombus] - Note length invalid: " + length);
         return undefined;
       }
 
-      if (!isNumber(velocity) || velocity < 0) {
+      if (!isNumber(velocity) || velocity < 0 || velocity > 1) {
          console.log("[Rhombus] - Note velocity invalid: " + velocity);
         return undefined;
       }
@@ -3540,9 +3545,12 @@
         var newTrack = new this.Track(trkId);
 
         newTrack._name = track._name;
-        newTrack._targets = track._targets;
-        for (var targetIdx = 0; targetIdx < newTrack._targets.length; targetIdx++) {
-          newTrack._targets[targetIdx] = +(newTrack._targets[targetIdx]);
+
+        if (isDefined(track._targets)) {
+          newTrack._targets = track._targets;
+          for (var targetIdx = 0; targetIdx < newTrack._targets.length; targetIdx++) {
+            newTrack._targets[targetIdx] = +(newTrack._targets[targetIdx]);
+          }
         }
 
         for (var itemId in playlist) {
@@ -3718,7 +3726,13 @@
               var note  = notes[i];
               var start = note.getStart() + itemStart;
 
+              // prevent notes from before the loop start from triggering
               if (!loopOverride && r.getLoopEnabled() && start < loopStart) {
+                continue;
+              }
+
+              // prevent other spurious note triggers
+              if (start >= itemEnd) {
                 continue;
               }
 
@@ -4094,7 +4108,6 @@
       });
     };
 
-    // TODO: investigate ways to rescale RtNotes that are currently playing
     r.Edit.changeNoteTime = function(noteId, start, length, ptnId) {
 
       if (start < 0 || length < 1) {
@@ -4184,6 +4197,84 @@
       });
 
       return noteId;
+    };
+
+    r.Edit.isValidTranslation = function(notes, pitchOffset, timeOffset) {
+      for (i = 0; i < notes.length; i++) {
+        var dstPitch = notes[i]._pitch + pitchOffset;
+        var dstStart = notes[i]._start + timeOffset;
+
+        // validate the translations
+        if (dstPitch > 127 || dstPitch < 0 || dstStart < 0) {
+          return false;
+        }
+      }
+
+      return true;
+    };
+
+    // TODO: possibly implement clamping in one form or another
+    r.Edit.translateNotes = function(ptnId, notes, pitchOffset, timeOffset) {
+      var i;
+
+      var ptn = r._song._patterns[ptnId];
+
+      if (notDefined(ptn)) {
+        console.log("[Rhombus.Edit] - pattern is not defined");
+        return false;
+      }
+
+      var newValues = new Array(notes.length);
+      var oldValues = new Array(notes.length);
+
+      var maxPitch = 0;
+      var minPitch = 127;
+      var minStart = 1e6;
+
+      // pre-compute and validate the translations before applying them
+      for (i = 0; i < notes.length; i++) {
+        var dstPitch = notes[i]._pitch + pitchOffset;
+        var dstStart = notes[i]._start + timeOffset;
+
+        maxPitch = (dstPitch > maxPitch) ? dstPitch : maxPitch;
+        minPitch = (dstPitch < minPitch) ? dstPitch : minPitch;
+        minStart = (dstStart < minStart) ? dstStart : minStart;
+
+        newValues[i] = [dstPitch, dstStart];
+        oldValues[i] = [notes[i]._pitch, notes[i]._start];
+      }
+
+      var pitchDiff = 0;
+      if (maxPitch > 127) {
+        pitchDiff = 127 - maxPitch;
+      }
+      else if (minPitch < 0) {
+        pitchDiff = -minPitch;
+      }
+
+      var startDiff = 0;
+      if (minStart < 0) {
+        startDiff = -minStart;
+      }
+
+      r.Undo._addUndoAction(function() {
+        for (var i = 0; i < notes.length; i++) {
+          ptn._noteMap._avl.delete(notes[i]._start, notes[i]);
+          notes[i]._pitch = oldValues[i][0];
+          notes[i]._start = oldValues[i][1];
+          ptn._noteMap._avl.insert(notes[i]._start, notes[i]);
+        }
+      });
+
+      // apply the translations
+      for (i = 0; i < notes.length; i++) {
+        ptn._noteMap._avl.delete(notes[i]._start, notes[i]);
+        notes[i]._pitch = newValues[i][0] + pitchDiff;
+        notes[i]._start = newValues[i][1] + startDiff;
+        ptn._noteMap._avl.insert(notes[i]._start, notes[i]);
+      }
+
+      return true;
     };
 
     // Makes a copy of the source pattern and adds it to the song's pattern set.

--- a/app/assets/templates/nodeproperties.html.erb
+++ b/app/assets/templates/nodeproperties.html.erb
@@ -141,7 +141,7 @@
     };
 
     nodepropertiesPrototype.detachedCallback = function(){
-      unsetEventHandlers(that);
+      unsetEventHandlers(this);
     };
 
     function setEventHandlers(that) {


### PR DESCRIPTION
I've added a function to translate an array of notes in pitch and time. The required parameters are a pattern ID, an array of notes from that pattern, and pitch and position offsets. 

The translation is 'clamped' to a valid range, so you don't need to worry about checking whether or not the translation is valid. Also, the relative pitch and timing of the notes is preserved -- the notes move together as a solid block.

I also fixed a couple of small bugs in Rhombus and the front-end.
