### PR TITLE
Note Velocity Update

### DIFF
--- a/app/assets/javascripts/rhombus.js
+++ b/app/assets/javascripts/rhombus.js
@@ -4592,9 +4592,14 @@
       return noteId;
     };
 
-    r.Edit.updateVelocities = function(notes, velocity) {
+    r.Edit.updateVelocities = function(notes, velocity, onlySelected) {
       if (notDefined(velocity) || !isNumber(velocity) || velocity < 0 || velocity > 1) {
         console.log("[Rhombus.Edit] - invalid velocity");
+        return false;
+      }
+
+      if (notDefined(onlySelected) || typeof onlySelected !== "boolean") {
+        console.log("[Rhombus.Edit] - onlySelected must be of type Boolean");
         return false;
       }
 
@@ -4602,6 +4607,9 @@
 
       for (var i = 0; i < notes.length; i++) {
         oldVelocities[i] = notes[i]._velocity;
+        if (onlySelected && !notes[i]._selected) {
+          continue;
+        }
         notes[i]._velocity = velocity;
       }
 

--- a/app/assets/templates/automation.html.erb
+++ b/app/assets/templates/automation.html.erb
@@ -55,6 +55,10 @@
           return rhomb.getSong().getPatterns()[that.ptnId].getAutomationEventsInRange(range.start, range.end);
       }
 
+      this.getSelectedNotes = function(){
+        return rhomb.getSong().getPatterns()[that.ptnId].getSelectedNotes();
+      }
+
       this.getRange = function(x){
         var tick = x * that.displaySettings.TPP;
         var delta = 5 * that.displaySettings.TPP;
@@ -113,8 +117,14 @@
         if(that.mode === "velocity"){
           // get the notes in this range
           that.selectedNotes = that.getNotesInRange(that.getRange(mouseX));
+
+          var onlySelected = false;
+          if (that.getSelectedNotes().length > 0) {
+            onlySelected = true;
+          }
+
           // edit the notes in rhombus
-          rhomb.Edit.updateVelocities(that.selectedNotes, getParamValue());
+          rhomb.Edit.updateVelocities(that.selectedNotes, getParamValue(), onlySelected);
         } else if(that.mode === "parameter"){
           // quantize the mouse location, then get notes in that range
           ticks = mouseX * that.displaySettings.TPP;
@@ -177,8 +187,14 @@
         }
         
         if(that.mode === "velocity" && that.button){
+
+          var onlySelected = false;
+          if (that.getSelectedNotes().length > 0) {
+            onlySelected = true;
+          }
+
           // edit the notes in rhombus
-          rhomb.Edit.updateVelocities(that.selectedNotes, getParamValue());
+          rhomb.Edit.updateVelocities(that.selectedNotes, getParamValue(), onlySelected);
         } else if(that.mode === "parameter"){
           if(that.deletebutton){
             rhomb.Edit.deleteAutomationEventsInRange(ticks, ticks + 1, that.ptnId);


### PR DESCRIPTION
I added an 'onlySelected' flag to updateVelocities, which if true makes it so that only selected notes will have their velocities updated. This is useful for editing the velocities of just the selected notes in the automation lane.
