### PR TITLE
Bugfixes and Select Mode in Automation Component

### DIFF
--- a/app/assets/templates/automation.html.erb
+++ b/app/assets/templates/automation.html.erb
@@ -308,6 +308,10 @@
             that.drawVelocity(notes, "#0000FF", "#9999FF");
           } else {
             that.drawVelocity(that.selectedNotes, "#0000FF", "#9999FF");
+
+            var vel = Math.round(that.selectedNotes[0].getVelocity() * 1000) / 1000.0;
+            var velEvent = new CustomEvent('denoto-notepane-updatevelocity', {detail: {"velocity": vel}});
+            document.dispatchEvent(velEvent);
           }
         } else if(that.mode === "parameter"){
           that.drawParameter(that.notes);

--- a/app/assets/templates/automation.html.erb
+++ b/app/assets/templates/automation.html.erb
@@ -211,7 +211,11 @@
             that.selectedNotes = selectedNotes;
           }
           else
+          {
+            if(that.getSelectedNotes().length > 0)
+              onlySelected = true;
             that.selectedNotes = that.getNotesInRange(that.getRange(mouseX));
+          }
 
           // edit the notes in rhombus
           rhomb.Edit.updateVelocities(that.selectedNotes, getParamValue(), onlySelected);
@@ -283,7 +287,7 @@
         
         if(that.mode === "velocity" && that.button){
 
-          var onlySelected = that.cursormode === "select";
+          var onlySelected = that.cursormode === "select" || (that.cursormode === "draw" && that.getSelectedNotes().length > 0);
 
           // edit the notes in rhombus
           rhomb.Edit.updateVelocities(that.selectedNotes, getParamValue(), onlySelected);

--- a/app/assets/templates/automation.html.erb
+++ b/app/assets/templates/automation.html.erb
@@ -19,6 +19,9 @@
     width: 100%;
     height: 75px;
   }
+  #preload{
+    display: none;
+  }
   </style>
   <div id="scroller">
   <div id="container">
@@ -26,6 +29,10 @@
   </div>
   </div>
   <div id="overlay"></div>
+  <div id="preload">
+    <img src='<%= asset_path("tb_pencil_cursor.png")%>' />
+    <img src='<%= asset_path("tb_cursor_auto.png")%>' />
+  </div>
 </template>
 <script src="<%= asset_path("automation.js")%>"></script>
 <script>
@@ -45,6 +52,7 @@
       var overlay = root.getElementById("overlay");
       var that = this;
       that.button = false;
+      that.cursormode = 'draw';
 
       that.mode = "velocity";
 
@@ -56,7 +64,11 @@
       }
 
       this.getSelectedNotes = function(){
-        return rhomb.getSong().getPatterns()[that.ptnId].getSelectedNotes();
+        var pattern = rhomb.getSong().getPatterns()[that.ptnId];
+        if(typeof pattern !== 'undefined')
+          return pattern.getSelectedNotes();
+        else
+          return undefined;
       }
 
       this.getRange = function(x){
@@ -92,6 +104,20 @@
         }
       });
 
+
+      document.addEventListener('denoto-selectmode', function() {
+        that.cursormode = 'select';
+        if(that.mode === "velocity")
+          overlay.style.cursor = 'url(<%= asset_path("tb_cursor_auto.png")%>) 12 3, auto';
+        else
+          overlay.style.cursor = 'url(<%= asset_path("tb_pencil_cursor.png")%>) 0 31, auto';  
+      });
+
+      document.addEventListener('denoto-drawmode', function() {
+        that.cursormode = 'draw';
+        overlay.style.cursor = 'url(<%= asset_path("tb_pencil_cursor.png")%>) 0 31, auto';
+      });
+
       function getMouseX(){
         var pageOffset = document.body.getBoundingClientRect();
         var offset = canvas.getBoundingClientRect();
@@ -105,6 +131,21 @@
         return 1 - (mouseY / offset.height);
       }
 
+      function isInVelocityRange(note, v){
+        var d = 0.05;
+        return (note.getVelocity() >= (v - d) && note.getVelocity() <= (v + d));
+      }
+
+      function filterByVelocity(notes, v){
+        var returnArr = [];
+        for(var i in notes){
+          if(isInVelocityRange(notes[i], v)){
+            returnArr.push(notes[i]);
+          }
+        }
+        return returnArr;
+      }
+
       overlay.addEventListener('mousedown', function(){
         event.preventDefault();
         var mouseX = getMouseX();
@@ -115,13 +156,62 @@
         that.deletebutton = (event.button === 2.0);
         
         if(that.mode === "velocity"){
-          // get the notes in this range
-          that.selectedNotes = that.getNotesInRange(that.getRange(mouseX));
-
           var onlySelected = false;
-          if (that.getSelectedNotes().length > 0) {
+
+          // get the notes in this range
+          if(that.cursormode === "select"){
             onlySelected = true;
+            selectedNotes = [];
+            var notesInRange = that.getNotesInRange(that.getRange(mouseX));
+            
+            if (that.getSelectedNotes().length > 0) {
+              selectedNotes = filterByVelocity(notesInRange, getParamValue());
+
+              // if the user clicked somewhere with no notes (in select mode), they're probably trying to deselect
+              if(selectedNotes.length === 0){
+                rhomb.getSong().getPatterns()[that.ptnId].clearSelectedNotes();
+
+                var redrawEvent = new CustomEvent("denoto-redrawallnotes", {});
+                document.dispatchEvent(redrawEvent);
+              } else {
+                var selected = false;
+                for(var i in selectedNotes){
+                  if(selectedNotes[i].getSelected()){
+                    selected = true;
+                    break;
+                  }
+                }
+
+                // if none of the clicked notes are selected, they're probably trying to select them
+                // so clear their existing selection, and use these. If not, then they will operate on their
+                // previously-selected notes
+                if(!selected){
+                  rhomb.getSong().getPatterns()[that.ptnId].clearSelectedNotes();
+                  for(var i in selectedNotes){
+                    selectedNotes[i].select();
+                  }
+
+                  var redrawEvent = new CustomEvent("denoto-redrawallnotes", {});
+                  document.dispatchEvent(redrawEvent);
+                } else {
+                  selectedNotes = that.getSelectedNotes();
+                }
+              }
+            } else {
+              selectedNotes = filterByVelocity(notesInRange, getParamValue());
+
+              for(var i in selectedNotes){
+                selectedNotes[i].select();
+              }
+
+              var redrawEvent = new CustomEvent("denoto-redrawallnotes", {});
+              document.dispatchEvent(redrawEvent);
+            }
+
+            that.selectedNotes = selectedNotes;
           }
+          else
+            that.selectedNotes = that.getNotesInRange(that.getRange(mouseX));
 
           // edit the notes in rhombus
           rhomb.Edit.updateVelocities(that.selectedNotes, getParamValue(), onlySelected);
@@ -155,13 +245,13 @@
       overlay.addEventListener('mouseup', function(){
         that.button = false;
         that.deletebutton = false;
-        that.selectedNotes = undefined;
+        that.selectedNotes = that.getSelectedNotes();
       });      
 
       document.addEventListener('mouseup', function(){
         that.button = false;
         that.deletebutton = false;
-        that.selectedNotes = undefined;
+        that.selectedNotes = that.getSelectedNotes();
       });
 
       overlay.addEventListener('mousemove', function(){
@@ -170,17 +260,22 @@
         var notes = [];
         var ticks;
         if(that.mode === "velocity"){
-          notes = that.getNotesInRange(that.getRange(mouseX));
+          if(that.cursormode === "select"){
+            notes = that.getNotesInRange(that.getRange(mouseX));
+            notes = filterByVelocity(notes, getParamValue());
+          } else {
+            notes = that.getNotesInRange(that.getRange(mouseX));
+          }
         } else if(that.mode === "parameter"){
           ticks = mouseX * that.displaySettings.TPP;
           ticks = Math.floor(ticks / that.displaySettings.quantization) * that.displaySettings.quantization;
         }
 
         if(notes.length > 0){
-          canvas.style.cursor = "pointer";
-          that.selectedNotes = notes;
+          if(that.mode === "parameter" || that.cursormode === "draw"){
+            that.selectedNotes = notes;
+          }
         } else {
-          canvas.style.cursor = "auto";
           if(that.button && that.mode === "velocity"){
             notes = that.selectedNotes;
           }
@@ -188,10 +283,7 @@
         
         if(that.mode === "velocity" && that.button){
 
-          var onlySelected = false;
-          if (that.getSelectedNotes().length > 0) {
-            onlySelected = true;
-          }
+          var onlySelected = that.cursormode === "select";
 
           // edit the notes in rhombus
           rhomb.Edit.updateVelocities(that.selectedNotes, getParamValue(), onlySelected);
@@ -212,7 +304,11 @@
         if(that.mode === "velocity"){
           that.drawVelocity(that.notes);
           // highlight the notes the mouse is currently over
-          that.drawVelocity(notes, "#0000FF", "#9999FF");
+          if(that.cursormode === "draw" || typeof that.selectedNotes === 'undefined' || that.selectedNotes.length === 0){
+            that.drawVelocity(notes, "#0000FF", "#9999FF");
+          } else {
+            that.drawVelocity(that.selectedNotes, "#0000FF", "#9999FF");
+          }
         } else if(that.mode === "parameter"){
           that.drawParameter(that.notes);
         }
@@ -220,10 +316,10 @@
 
       overlay.addEventListener('mouseout', function(){
         if(!that.button){
-          that.selectedNotes = undefined;
+          that.selectedNotes = that.getSelectedNotes();
           that.clearCanvas();
           if(that.mode === "velocity"){
-            that.drawVelocity(that.notes);
+            that.redrawVelocity();
           } else if (that.mode === "parameter"){
             that.drawParameter(that.notes);
           }
@@ -261,6 +357,8 @@
         that.notes = that.getNotesInRange({"start": 0, "end": that.displaySettings.endmarkerticks});
         that.clearCanvas();
         that.drawVelocity(that.notes);
+        if(typeof that.selectedNotes !== 'undefined')
+          that.drawVelocity(that.selectedNotes, "#0000FF", "#9999FF");
       }
 
       this.redrawParameters = function(){

--- a/app/assets/templates/effectsgraph.html.erb
+++ b/app/assets/templates/effectsgraph.html.erb
@@ -256,10 +256,6 @@
     var root = this.createShadowRoot();
     root.appendChild(document.importNode(template.content, true));
 
-    // prevent the background from being highlit
-    root.getElementById("tlwrapper").addEventListener("mousedown", function(){ event.preventDefault(); });
-    root.getElementById("tlbg").addEventListener("mousedown", function(){ event.preventDefault(); });
-
     // move to container component when separating this
     effectsgraphholder = root.host;
 

--- a/app/assets/templates/effectsgraph.html.erb
+++ b/app/assets/templates/effectsgraph.html.erb
@@ -256,6 +256,10 @@
     var root = this.createShadowRoot();
     root.appendChild(document.importNode(template.content, true));
 
+    // prevent the background from being highlit
+    root.getElementById("tlwrapper").addEventListener("mousedown", function(){ event.preventDefault(); });
+    root.getElementById("tlbg").addEventListener("mousedown", function(){ event.preventDefault(); });
+
     // move to container component when separating this
     effectsgraphholder = root.host;
 

--- a/app/assets/templates/pianoroll.html.erb
+++ b/app/assets/templates/pianoroll.html.erb
@@ -473,7 +473,7 @@
         // put the current marker at the beginning of this instance of the pattern (only if not playing)
         if (!rhomb.isPlaying() && typeof event.detail.start !== 'undefined') {
           rhomb.moveToPositionTicks(event.detail.start);
-        } 
+        }
         if (typeof event.detail.start !== 'undefined')
           displaySettings.startOffsetTicks = event.detail.start;
 
@@ -566,6 +566,14 @@
         screenposition.style.width = (width * pianoroll.clientWidth) / pianoroll.scrollWidth + "px";
         footerCanvas.style.width = width + "px";
       }
+
+      this.redrawAllNotes = function(){
+      	redrawAllNotes(root, that.pattern.getAllNotes(), displaySettings);
+      	var selectedNotes = that.pattern.getSelectedNotes();
+      	setNotePropertiesPane(selectedNotes);
+      	setGroupPropertiesPane(selectedNotes);
+      	showPanes();
+      };
 
       this.documentMousemove = function() {
         var pageOffset = document.body.getBoundingClientRect();
@@ -1309,6 +1317,9 @@
             redrawAllNotes(root, that.pattern.getAllNotes(), displaySettings);
           }
 
+          var autoEvent = new CustomEvent("denoto-refreshautomation", {});
+        	document.dispatchEvent(autoEvent);
+
           setNotePropertiesPane(selectedNotes);
         }
       }
@@ -1392,6 +1403,7 @@
       document.addEventListener('denoto-updatelengthquantization', this.handleUpdateLengthQuantization);
       root.host.addEventListener('denoto-applydisplaysettings', this.applyDisplaySettings);
       window.addEventListener('scroll', this.handleScroll);
+      document.addEventListener('denoto-redrawallnotes', this.redrawAllNotes);
 
       var bgImage = bgCanvas.toDataURL();
       this.shadowRoot.getElementById('filler').style.backgroundImage = "url(" + bgImage + ")";
@@ -1420,6 +1432,7 @@
       document.removeEventListener('denoto-updatelengthquantization', this.handleUpdateLengthQuantization);
       root.host.removeEventListener('denoto-applydisplaysettings', this.applyDisplaySettings);
       window.removeEventListener('scroll', this.handleScroll);
+      document.removeEventListener('denoto-redrawallnotes', this.redrawAllNotes);
 
       var tab = document.getElementById("tabset").shadowRoot.getElementById("pattern" + that.ptnId);
       var displaysettingsEvent = new CustomEvent('denoto-displaysettings', {"detail": {"displaySettings": displaySettings, "source": that}});

--- a/app/assets/templates/pianoroll.html.erb
+++ b/app/assets/templates/pianoroll.html.erb
@@ -575,6 +575,10 @@
       	showPanes();
       };
 
+      this.handleNotePaneUpdateVelocity = function(){
+      	note_velocity.setAttribute("value", event.detail.velocity);
+      };
+
       this.documentMousemove = function() {
         var pageOffset = document.body.getBoundingClientRect();
         var offset = overlayCanvas.getBoundingClientRect();
@@ -1404,6 +1408,7 @@
       root.host.addEventListener('denoto-applydisplaysettings', this.applyDisplaySettings);
       window.addEventListener('scroll', this.handleScroll);
       document.addEventListener('denoto-redrawallnotes', this.redrawAllNotes);
+      document.addEventListener('denoto-notepane-updatevelocity', this.handleNotePaneUpdateVelocity);
 
       var bgImage = bgCanvas.toDataURL();
       this.shadowRoot.getElementById('filler').style.backgroundImage = "url(" + bgImage + ")";
@@ -1433,6 +1438,7 @@
       root.host.removeEventListener('denoto-applydisplaysettings', this.applyDisplaySettings);
       window.removeEventListener('scroll', this.handleScroll);
       document.removeEventListener('denoto-redrawallnotes', this.redrawAllNotes);
+      document.removeEventListener('denoto-notepane-updatevelocity', this.handleNotePaneUpdateVelocity);
 
       var tab = document.getElementById("tabset").shadowRoot.getElementById("pattern" + that.ptnId);
       var displaysettingsEvent = new CustomEvent('denoto-displaysettings', {"detail": {"displaySettings": displaySettings, "source": that}});

--- a/app/assets/templates/pianoroll.html.erb
+++ b/app/assets/templates/pianoroll.html.erb
@@ -482,6 +482,9 @@
 
         that.trackIndex = event.detail.trackIndex;
 
+        // set the global target to play this instrument
+        rhomb.setGlobalTarget(event.detail.trackIndex);
+
         var displaysettingsEvent = new CustomEvent('denoto-getdisplaysettings', {"detail": undefined});
         var tab = document.getElementById("tabset").shadowRoot.getElementById("pattern" + that.ptnId);
         tab.dispatchEvent(displaysettingsEvent);

--- a/app/assets/templates/pianoroll.html.erb
+++ b/app/assets/templates/pianoroll.html.erb
@@ -943,7 +943,8 @@
           note_start.setAttribute("value", notes[0].getStart());
           note_length.setAttribute("value", notes[0].getLength());
           note_pitch.setAttribute("value", notes[0].getPitch());
-          note_velocity.setAttribute("value", notes[0].getVelocity());
+          var vel = Math.round(notes[0].getVelocity() * 1000) / 1000.0;
+          note_velocity.setAttribute("value", vel);
         } else {
           // clear the note properties in the window
           note_start.setAttribute("value", "");

--- a/app/assets/templates/pianoroll.html.erb
+++ b/app/assets/templates/pianoroll.html.erb
@@ -505,6 +505,10 @@
 
         // add scroll handling here
         that.scrollToCoord(displaySettings.scrollCoord);
+        if(typeof displaySettings.vScroll !== 'undefined')
+        	window.scrollTo(0, displaySettings.vScroll);
+        else
+        	window.scrollTo(0, 1270); // middle C, I think...
       };
 
       // listen to events thrown to this pattern editor
@@ -625,6 +629,11 @@
         var velocityEvent = new CustomEvent("denoto-setinsertvelocity", {"detail": {"velocity": insertVelocity}});
         document.dispatchEvent(velocityEvent);
       }
+
+
+	    this.handleScroll = function(){
+	      displaySettings.vScroll = window.scrollY;
+	    };
 
       this.rendering = false;
 
@@ -1379,6 +1388,7 @@
       document.addEventListener('denoto-updatequantization', this.handleUpdateQuantization);
       document.addEventListener('denoto-updatelengthquantization', this.handleUpdateLengthQuantization);
       root.host.addEventListener('denoto-applydisplaysettings', this.applyDisplaySettings);
+      window.addEventListener('scroll', this.handleScroll);
 
       var bgImage = bgCanvas.toDataURL();
       this.shadowRoot.getElementById('filler').style.backgroundImage = "url(" + bgImage + ")";
@@ -1406,6 +1416,7 @@
       document.removeEventListener('denoto-updatequantization', this.handleUpdateQuantization);
       document.removeEventListener('denoto-updatelengthquantization', this.handleUpdateLengthQuantization);
       root.host.removeEventListener('denoto-applydisplaysettings', this.applyDisplaySettings);
+      window.removeEventListener('scroll', this.handleScroll);
 
       var tab = document.getElementById("tabset").shadowRoot.getElementById("pattern" + that.ptnId);
       var displaysettingsEvent = new CustomEvent('denoto-displaysettings', {"detail": {"displaySettings": displaySettings, "source": that}});

--- a/app/assets/templates/whitekey.html.erb
+++ b/app/assets/templates/whitekey.html.erb
@@ -14,10 +14,17 @@
       display: none;
       -webkit-user-drag: none;
     }
+    #noteValue{
+      position: absolute;
+      right: 10px;
+      top: 27%;
+      display: none;
+    }
   </style>
   <div id="container">
     <img id="up" src='<%= asset_path("whitekey_up.png")%>' />
     <img id="down" src='<%= asset_path("whitekey_down.png")%>' />
+    <div id="noteValue"></div>
   </div>
 </template>
 
@@ -65,6 +72,19 @@
           clicked = false;
         }
       });
+    };
+
+    whitekeyPrototype.attributeChangedCallback = function(attrName, oldVal, newVal) {
+      var that = this;
+      var root = that.shadowRoot;
+      if(attrName.toLowerCase() === "value"){
+        var val = parseInt(newVal);
+        if(val % 12 === 0 || val === 127){
+          var val_display =   root.getElementById("noteValue");
+          val_display.innerText = val;
+          val_display.style.display = "block";
+        }
+      }
     };
 
     // register the element


### PR DESCRIPTION
Scroll position is now saved in pianoroll tabs, and defaults to middle C if no position has been saved. Global target is once again set when entering pattern editor.

Select mode (where notes can be selected/deselected, and only selected notes are modified) has been added to the automation component. The cursor (pointer vs. pencil) is determined by Select vs Draw mode. Draw mode behaves like the automation component previously did.
