### PR TITLE
Bug fixed: unable to draw notes when snap is disabled

### DIFF
--- a/app/assets/templates/pianoroll.html.erb
+++ b/app/assets/templates/pianoroll.html.erb
@@ -1155,7 +1155,7 @@
         else
         { // draw mode
           mouse = snapToFloor(mouse);
-          var length = displaySettings.snapto ? displaySettings.length_quantization : 0;
+          var length = displaySettings.snapto ? displaySettings.length_quantization : 1;
           preview = new rhomb.Note(+mouse.pitch, +mouse.tick, +length, +insertVelocity);
           Xoffset = mouse.x;
 


### PR DESCRIPTION
Due to an initial length of 0 with snap disabled, the preview note was being rejected from rhombus's Note() constructor, preventing a length from being added later. Now an initial length of 1 is used when snap is disabled.
