### PR TITLE
MIDI Tweaks

### DIFF
--- a/app/assets/javascripts/rhombus.js
+++ b/app/assets/javascripts/rhombus.js
@@ -4257,7 +4257,7 @@
       }
 
       // Flush any notes that might be lingering
-      lastScheduled = this.seconds2Ticks(time);
+      lastScheduled = roundTick(this.seconds2Ticks(time), 15);
       this.killAllNotes();
 
       playing = true;

--- a/app/assets/javascripts/rhombus.js
+++ b/app/assets/javascripts/rhombus.js
@@ -98,7 +98,6 @@
     root.Rhombus._editSetup(this);
 
     this.initSong();
-    this.getMidiAccess();
   };
 
 })(this);
@@ -5316,14 +5315,14 @@
       // check for note-off messages
       if (cmd === 0x80 || (cmd === 0x90 && vel === 0)) {
         console.log("[MidiIn] - Note-Off, pitch: " + pitch + "; velocity: " + vel.toFixed(2));
-        rhomb.stopPreviewNote(pitch);
+        r.stopPreviewNote(pitch);
       }
 
       // check for note-on messages
       else if (cmd === 0x90 && vel > 0) {
         vel /= 127;
         console.log("[MidiIn] - Note-On, pitch: " + pitch + "; velocity: " + vel.toFixed(2));
-        rhomb.startPreviewNote(pitch, vel);
+        r.startPreviewNote(pitch, vel);
       }
 
       // don't worry about other message types for now
@@ -5355,6 +5354,10 @@
       if (typeof navigator.requestMIDIAccess !== "undefined") {
         navigator.requestMIDIAccess().then(onMidiSuccess, onMidiFailure);
       }
+    };
+
+    r.enableMidi = function() {
+      this.getMidiAccess();
     };
   };
 })(this.Rhombus);

--- a/app/assets/templates/pianoroll.html.erb
+++ b/app/assets/templates/pianoroll.html.erb
@@ -1035,6 +1035,9 @@
       function quantizeLengthFloor(ticks){
         if (displaySettings.snapto) {
           var adjustment = displaySettings.length_quantization;
+          if (displaySettings.length_quantization === "insert") {
+            adjustment = displaySettings.quantization;
+          }
           ticks = Math.floor(ticks / adjustment) * adjustment;
         }
         return ticks;
@@ -1043,6 +1046,9 @@
       function quantizeLengthCeil(ticks){
         if (displaySettings.snapto) {
           var adjustment = displaySettings.length_quantization;
+          if (displaySettings.length_quantization === "insert") {
+            adjustment = displaySettings.quantization;
+          }
           ticks = Math.ceil(ticks / adjustment) * adjustment;
         }
         return ticks;
@@ -1155,7 +1161,9 @@
         else
         { // draw mode
           mouse = snapToFloor(mouse);
-          var length = displaySettings.snapto ? displaySettings.length_quantization : 0;
+          var quantVal = (displaySettings.length_quantization === "insert") ?
+            displaySettings.quantization : displaySettings.length_quantization;
+          var length = displaySettings.snapto ? quantVal : 0;
           preview = new rhomb.Note(+mouse.pitch, +mouse.tick, +length, +insertVelocity);
           Xoffset = mouse.x;
 

--- a/app/assets/templates/quantization.html.erb
+++ b/app/assets/templates/quantization.html.erb
@@ -2,7 +2,7 @@
   <div id="quantizationcontrol">
     Snap <input id="snapto" type="checkbox" checked></input>
     <!--Quantization: <denoto-editabletext id="quantization" type="tinytext" prefix="1/" value="16" suffix=" Note"></denoto-editabletext>-->
-    Quantization: 
+    Insert Quantize: 
     <select id="quantization">
       <option value="0">1/1</option>
       <option value="1">1/2</option>

--- a/app/views/tracks/_audio_player.js.erb
+++ b/app/views/tracks/_audio_player.js.erb
@@ -144,6 +144,7 @@ $.ajax({
   success: function(data) {
     window["rhom-" + "<%= track.id %>"] = new DenotoRhombus();
     window["rhom-" + "<%= track.id %>"].importSong(JSON.stringify(data));
+    window["rhom-" + "<%= track.id %>"].Undo._clearUndoStack();
   },
   error: function (request, status, error) {
       console.log(request);

--- a/app/views/tracks/new.html.erb
+++ b/app/views/tracks/new.html.erb
@@ -156,6 +156,8 @@
 
   rhomb.Undo._clearUndoStack();
 
+  rhomb.enableMidi();
+
   document.addEventListener("denoto-setinsertvelocity",
     function(e){
       previewVelocity = e.detail.velocity;

--- a/app/views/tracks/new.html.erb
+++ b/app/views/tracks/new.html.erb
@@ -154,6 +154,8 @@
 
   var previewVelocity = 0.5;
 
+  rhomb.Undo._clearUndoStack();
+
   document.addEventListener("denoto-setinsertvelocity",
     function(e){
       previewVelocity = e.detail.velocity;

--- a/app/views/tracks/new.html.erb
+++ b/app/views/tracks/new.html.erb
@@ -173,25 +173,6 @@
       rhomb.stopPreviewNote(e.detail.keyvalue);
     });
 
-  // piano roll events
-  /*
-  document.addEventListener("denoto-writenote",
-    function(e){
-      console.log("[PianoRoll] Writing note ID " + e.detail.note._id + " at tick " + e.detail.note._start + ", length " + e.detail.note._length + ", pitch " + e.detail.note._pitch);
-      rhomb.Edit.insertNote(e.detail.note, e.detail.ptnId);
-    });
-  document.addEventListener("denoto-erasenote",
-    function(e){
-      console.log("[PianoRoll] Erasing note ID " + e.detail.note._id + " at tick " + e.detail.note._start);
-      rhomb.Edit.deleteNote(e.detail.note._id, e.detail.ptnId);
-    });
-  document.addEventListener("denoto-updatenote",
-  function(e){
-    //console.log("[PianoRoll] Updating note ID " + e.detail.id + " at tick " + e.detail.start + ", length " + e.detail.length);
-    //rhomb.Edit.changeNoteTime(e.detail.id, e.detail.start, e.detail.length, e.detail.ptnId);
-  });
-  */
-
   document.addEventListener("denoto-updatestartpos",
     function(e) {
       // TODO: determine if it's better to always update the start position,
@@ -228,22 +209,23 @@
   document.getElementById("transportbar").addEventListener("denoto-stop",
      function(e){ 
       console.log("[TransportBar] Stop pressed");
-      rhomb.stopPlayback();
 
-      var curPos = rhomb.seconds2Ticks(rhomb.getPosition());
-
-      if (startPosition == curPos) {
-        rhomb.moveToPositionTicks(rhomb.getLoopStart());
+      if (rhomb.isPlaying()) {
+        rhomb.stopPlayback();
+        var curPos = rhomb.seconds2Ticks(rhomb.getPosition());
+        if (rhomb.getLoopEnabled() && curPos > rhomb.getLoopStart()) {
+          rhomb.moveToPositionTicks(rhomb.getLoopStart());
+        }
+        else {
+          rhomb.moveToPositionTicks(0);
+        }
       }
       else {
-        rhomb.moveToPositionTicks(startPosition);
+        rhomb.moveToPositionTicks(0);
       }
 
       var posEvent = new CustomEvent("denoto-updatestartpos");
       document.dispatchEvent(posEvent);
-
-      // TODO: could be redundant
-      startPosition = rhomb.seconds2Ticks(rhomb.getPosition());
     });
 
   document.addEventListener('rhombus-stop', function() {
@@ -260,8 +242,6 @@
   function updateLoopEnd(e){    
     rhomb.setLoopEnd(event.detail.end);
   }
-  
-  //document.getElementById("transportbar").addEventListener("denoto-fastfwd", function(e){ console.log("[TransportBar] Fastfwd pressed") });
 
   document.getElementById("transportbar").addEventListener("denoto-loopToggle",
      function(e){ 


### PR DESCRIPTION
I have added a function to explicitly enable MIDI input (if it's available) in Rhombus. This is to prevent the track player from accepting MIDI input. I also fixed a few small bugs and made sure the undo stack is cleared after Rhombus is loaded (to prevent the master node from being removed by applying too many undos).
