### PR TITLE
Tab Close Fix

### DIFF
--- a/app/assets/templates/pianoroll.html.erb
+++ b/app/assets/templates/pianoroll.html.erb
@@ -458,8 +458,13 @@
         // save current tab's settings if switching to a different tab
         if(typeof that.ptnId !== 'undefined'){
           var tab = document.getElementById("tabset").shadowRoot.getElementById("pattern" + that.ptnId);
-          var displaysettingsEvent = new CustomEvent('denoto-displaysettings', {"detail": {"displaySettings": JSON.parse(JSON.stringify(displaySettings)), "source": that}});
-          tab.dispatchEvent(displaysettingsEvent);
+          if (typeof tab === "undefined" || !tab) {
+            console.log("[PianoRoll] - tab is undefined or null");
+          }
+          else {
+            var displaysettingsEvent = new CustomEvent('denoto-displaysettings', {"detail": {"displaySettings": JSON.parse(JSON.stringify(displaySettings)), "source": that}});
+            tab.dispatchEvent(displaysettingsEvent);
+          }
         }
 
         playlistItem = event.detail.playlistItem;
@@ -488,9 +493,14 @@
         // set the global target to play this instrument
         rhomb.setGlobalTarget(event.detail.trackIndex);
 
-        var displaysettingsEvent = new CustomEvent('denoto-getdisplaysettings', {"detail": undefined});
         var tab = document.getElementById("tabset").shadowRoot.getElementById("pattern" + that.ptnId);
-        tab.dispatchEvent(displaysettingsEvent);
+        if (typeof tab === "undefined" || !tab) {
+          console.log("[PianoRoll] - tab is undefined or null");
+        }
+        else {
+          var displaysettingsEvent = new CustomEvent('denoto-getdisplaysettings', {"detail": undefined});
+          tab.dispatchEvent(displaysettingsEvent);
+        }
 
         redrawEverything();
       });

--- a/app/assets/templates/tab.html.erb
+++ b/app/assets/templates/tab.html.erb
@@ -87,8 +87,14 @@
       });
 
       document.addEventListener("denoto-removepattern", function() {
-        if (that.getAttribute("id") === ("pattern" + event.detail.index))
-          root.host.parentNode.removeChild(root.host);
+        if (that.getAttribute("id") === ("pattern" + event.detail.index)) {
+          if (typeof root.host.parentNode == "undefined" || !root.host.parentNode) { 
+            console.log("[Tab] - parentNode is undefined or null");
+          }
+          else {
+            root.host.parentNode.removeChild(root.host);
+          }
+        }
       });
 
       document.addEventListener("denoto-renamepattern", function() {

--- a/app/assets/templates/whitekey.html.erb
+++ b/app/assets/templates/whitekey.html.erb
@@ -19,6 +19,7 @@
       right: 10px;
       top: 27%;
       display: none;
+      -webkit-user-select: none;
     }
   </style>
   <div id="container">


### PR DESCRIPTION
Functions were being called on undefined/null tab variables in the pianoroll which made it impossible to switch to other tabs after closing one. I think this fixes it, but more seasoned eyes should probably look it over.
