### PR TITLE
Updated rhombus to use caja again for script processor node

### DIFF
--- a/app/assets/javascripts/rhombus.js
+++ b/app/assets/javascripts/rhombus.js
@@ -849,7 +849,6 @@
     "decay"    : [Rhombus._map.timeMapFn,     secondsDisplay, 0.25],
     "sustain"  : [Rhombus._map.mapIdentity,   rawDisplay,     1.0],
     "release"  : [Rhombus._map.timeMapFn,     secondsDisplay, 0.0],
-    "exponent" : [Rhombus._map.exponentMapFn, rawDisplay,     0.5]
   };
 
   Rhombus._map.filterMap = {
@@ -870,7 +869,6 @@
     "release"  : [Rhombus._map.timeMapFn,     secondsDisplay, 0.25],
     "min"      : [Rhombus._map.freqMapFn,     hzDisplay,      0.0],
     "max"      : [Rhombus._map.freqMapFn,     hzDisplay,      0.0],
-    "exponent" : [Rhombus._map.exponentMapFn, rawDisplay,     0.5]
   };
 
 })(this.Rhombus);

--- a/app/assets/javascripts/rhombusload.js
+++ b/app/assets/javascripts/rhombusload.js
@@ -10,6 +10,11 @@
 
       infoReq.onload = function() {
         var infoMap = infoReq.response;
+        if (!infoMap) {
+          console.log("[Rhombus] Couldn't get sample info from \"" + dirPath + "samples.json\"");
+          return;
+        }
+
         var sampleCount = Object.keys(infoMap).length;
 
         var finalMap = {};


### PR DESCRIPTION
The script node uses caja again (so it's no longer unsafe like it was), but the performance is vastly improved.
