### PR TITLE
Music editor scrolls with music playback

### DIFF
--- a/app/assets/templates/endmarker.html.erb
+++ b/app/assets/templates/endmarker.html.erb
@@ -9,6 +9,7 @@
       top: 10px;
       display: inline-block;
       width: 160px;
+      z-index: 4;
     }
   </style>
 </template>

--- a/app/assets/templates/loopcontrol.html.erb
+++ b/app/assets/templates/loopcontrol.html.erb
@@ -14,6 +14,7 @@
       position: relative;
       top: 10px;
       display: inline-block;
+      z-index: 4;
     }
     .blocker{
       display: inline-block;

--- a/app/assets/templates/musicclock.html.erb
+++ b/app/assets/templates/musicclock.html.erb
@@ -12,6 +12,7 @@
       position: relative;
       top: 10px;
       display: inline-block;
+      z-index: 4;
     }
     #spacer{
       display: inline-block;

--- a/app/assets/templates/pianoroll.html.erb
+++ b/app/assets/templates/pianoroll.html.erb
@@ -778,6 +778,13 @@
           var ticks = rhomb.seconds2Ticks(rhomb.getPosition());
           drawTimeMarker(overlayContext, ticks, overlayCanvas.getAttribute("height"), displaySettings);
 
+          if(that.scrollWithMusic){
+            var scrollTo = ((ticks - displaySettings.startOffsetTicks) / displaySettings.TPP) * 0.9;
+            if((pianoroll.scrollLeft + window.innerWidth * 0.5) < scrollTo){
+              pianoroll.scrollLeft = scrollTo - window.innerWidth * 0.5;
+            }
+          }
+
           // The tick value can become negative when playback loops around
           // This is to 'correct' the tick value so that the time display is more accurate
           if (ticks < 0) {
@@ -1000,6 +1007,7 @@
         // move the time marker as necessary
         document.addEventListener('denoto-play', function() {
           playing = true;
+          that.scrollWithMusic = true;
           render();
         });
 
@@ -1013,6 +1021,7 @@
 
         document.addEventListener('rhombus-start', function() {
           playing = true;
+          that.scrollWithMusic = true;
           render();
         });
 
@@ -1228,6 +1237,7 @@
 
       // handles mouse down events within the canvas
       function handleMousedown() {
+        that.scrollWithMusic = false;
         event.preventDefault();
         button = event.button;
         var mouse = getMousePosition(canvas);

--- a/app/assets/templates/quantization.html.erb
+++ b/app/assets/templates/quantization.html.erb
@@ -41,6 +41,7 @@
       position: relative;
       top: 10px;
       display: inline-block;
+      z-index: 4;
     }
   </style>
 </template>

--- a/app/assets/templates/tracklist.html.erb
+++ b/app/assets/templates/tracklist.html.erb
@@ -2,6 +2,9 @@
   <div id="container">
     <div id="tracklist"></div>
     <div id="covercontainer"><div id="rowcover"><span id="addtext"><h3>Click to add a new track</h3></span></div></div>
+    <div id="addbutton">
+      <div id="addbuttontext"><span class="add_track_text">Add New Track</span><div>
+    </div>
   </div>
   <style>
   #covercontainer{
@@ -35,9 +38,29 @@
     position: relative;
     top: -5px;
   }
-  .pianokey {
-    padding: 0px;
-    margin: 0px;
+  #addbutton{
+    position: relative;
+    top: 0px;
+    background: #243544;
+    width: 125px;
+    height: 50px;
+    color: #FFF;
+    z-index: 5;
+    text-align: center;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    display: none;
+  }
+  #addbutton:hover{
+    background: #000000;
+    opacity: 0.5;
+    cursor: pointer;
+  }
+  #addbuttontext {
+    padding-top: 10px;
+  }
+  .add_track_text {
+    opacity: 0.9;
   }
  </style>
 </template>
@@ -64,6 +87,7 @@
       var hiderowcover = this.getAttribute("hiderowcover");
       if(hiderowcover !== null && hiderowcover.toLowerCase() === "true"){
         this.shadowRoot.getElementById("rowcover").style.display = "none";
+        this.shadowRoot.getElementById("addbutton").style.display = "block";
       }
 
       document.addEventListener('denoto-setwidths', function() {
@@ -107,7 +131,7 @@
         createTrack(that, event.detail.track, event.detail.index);
       }
 
-      root.getElementById("rowcover").addEventListener("mouseup", function() {
+      function handleAddTrack(){
         event.preventDefault();
 
         if (that.changingInstrument) {
@@ -132,7 +156,10 @@
           root.host.dispatchEvent(trackEvent);
           document.dispatchEvent(trackEvent);
         }
-      });
+      }
+
+      root.getElementById("rowcover").addEventListener("mouseup", handleAddTrack);
+      root.getElementById("addbutton").addEventListener("mouseup", handleAddTrack);
 
       //root.host.ownerDocument.addEventListener('denoto-deletealltracks', function() {
       root.host.addEventListener('denoto-deletealltracks', function() {

--- a/app/assets/templates/trackview.html.erb
+++ b/app/assets/templates/trackview.html.erb
@@ -661,6 +661,10 @@
         }
       });
 
+      trackview.addEventListener('mousedown', function(){
+        showPanes();
+      });
+
       overlayCanvas.addEventListener('dragleave', function(){
         redrawTracks();
       });

--- a/app/assets/templates/trackview.html.erb
+++ b/app/assets/templates/trackview.html.erb
@@ -654,7 +654,11 @@
         draggedPattern._xoffset = event.detail._xoffset;
       });
 
-      overlayCanvas.addEventListener('dragover', function() {
+      overlayCanvas.addEventListener('dragleave', function(){
+        redrawTracks();
+      });
+
+      overlayCanvas.addEventListener('dragover', function(){
         event.preventDefault();
         button = undefined;
         overlayCanvas.style.cursor = 'url(<%= asset_path("tb_cursor_auto.png")%>) 12 3, auto';
@@ -860,6 +864,7 @@
       }
 
       this.documentMouseup = function() {
+        redrawTracks();
         if (typeof previewMarker !== 'undefined')
           endmarkerMouseup();
         else if (typeof loopbarPreview !== 'undefined')
@@ -1689,6 +1694,8 @@
                 pattern_length.setAttribute("value", trackset.currentPattern.getLength());
               }
             }
+
+            redrawTracks();
           }
 
           // update the overview image on the footer

--- a/app/assets/templates/trackview.html.erb
+++ b/app/assets/templates/trackview.html.erb
@@ -913,6 +913,13 @@
           var ticks = rhomb.seconds2Ticks(rhomb.getPosition());
           drawTimeMarker(overlayContext, ticks, overlayCanvas.getAttribute("height"), displaySettings);
 
+          if(that.scrollWithMusic){
+            var scrollTo = (ticks / displaySettings.TPP) * 0.9;
+            if((trackview.scrollLeft + window.innerWidth * 0.5) < scrollTo){
+              trackview.scrollLeft = scrollTo - window.innerWidth * 0.5;
+            }
+          }
+
           // The tick value can become negative when playback loops around
           // This is to 'correct' the tick value so that the time display is more accurate
           if (ticks < 0) {
@@ -1127,6 +1134,7 @@
 
         // move the time marker as necessary
         document.addEventListener('denoto-play', function() {
+          that.scrollWithMusic = true;
           playing = true;
           render();
         });
@@ -1293,6 +1301,7 @@
 
       // handles mouse down events within the canvas
       function handleMousedown() {
+        that.scrollWithMusic = false;
         redrawEverything();
 
         overlayCanvas.style.cursor = 'url(<%= asset_path("tb_cursor_auto.png")%>) 12 3, auto';

--- a/app/assets/templates/trackview.html.erb
+++ b/app/assets/templates/trackview.html.erb
@@ -654,6 +654,13 @@
         draggedPattern._xoffset = event.detail._xoffset;
       });
 
+      overlayCanvas.addEventListener('mouseout', function(){
+        if(typeof button === 'undefined'){
+          trackset.previousPattern = undefined;
+          trackset.currentPattern = undefined;
+        }
+      });
+
       overlayCanvas.addEventListener('dragleave', function(){
         redrawTracks();
       });

--- a/app/views/tracks/new.html.erb
+++ b/app/views/tracks/new.html.erb
@@ -17,7 +17,6 @@
   <script src="<%= asset_path("graph.js")%>"></script>
   <script src="<%= asset_path("recorder.js")%>"></script>
 </head>
-<!-- background: #252477; old purplish color 062A78-->
 <style type="text/css">
   @font-face{
     font-family: 'Oswald';
@@ -72,6 +71,19 @@
     top: 60px;
     left: 125px;
     width: 100%;
+    z-index: 3;
+  }
+  #loopcontrol{
+    z-index: 4;
+  }
+  #quantizationcontrol{
+    z-index: 4;
+  }
+  #musicclock{
+    z-index: 4;
+  }
+  #endmarkercontrol{
+    z-index: 4;
   }
 </style>
 


### PR DESCRIPTION
Music editor scrolls with music playback when the cursor goes far enough to the right (to prevent jumping around when looping). Click in the lanes (i.e. draw or select) to disable scrolling until you press play again.
