### PR TITLE
Pianoroll Single-Select

### DIFF
--- a/app/assets/javascripts/rhombus.js
+++ b/app/assets/javascripts/rhombus.js
@@ -3222,19 +3222,40 @@ Rhombus.prototype.getGlobalTarget = function() {
 
       getNotesAtTick: function(tick, lowPitch, highPitch, single) {
         var selection = this._noteMap.getNotesAtTick(tick, lowPitch, highPitch);
-
         if (notDefined(selection) || selection.length < 2 || notDefined(single) || !single) {
           return selection;
         }
 
-        var shortest = selection[0];
+        if (highPitch !== lowPitch) {
+          console.log("[Rhombus] - single select only works for a single pitch");
+          return undefined;
+        }
+
+        var shortest = undefined;
+        var shortestLength = 1e6;
 
         for (var i = 0; i < selection.length; i++) {
           var note = selection[i];
-          shortest = (note._length < shortest._length) ? note : shortest;
+
+          // ignore already-selected notes
+          if (note._selected) {
+            continue;
+          }
+
+          // find the shortest note
+          if (note._length < shortestLength) {
+            shortest = note;
+            shortestLength = note._length;
+          }
         }
 
-        return [shortest];
+        // if there is no shortest note, then all the notes at the tick are already selected
+        if (notDefined(shortest)) {
+          return selection;
+        }
+        else {
+          return [shortest];
+        }
       },
 
       getSelectedNotes: function() {

--- a/app/assets/templates/pianoroll.html.erb
+++ b/app/assets/templates/pianoroll.html.erb
@@ -1241,7 +1241,8 @@
         event.preventDefault();
         button = event.button;
         var mouse = getMousePosition(canvas);
-        var clickedNotes = that.pattern.getNotesAtTick(Math.round(mouse.tick), mouse.pitch, mouse.pitch);
+        var singleSelect = true;
+        var clickedNotes = that.pattern.getNotesAtTick(Math.round(mouse.tick), mouse.pitch, mouse.pitch, singleSelect);
 
         if(button === 2){
           that.pattern.deleteNotes(clickedNotes);
@@ -1341,7 +1342,8 @@
 
       function handleMousemove() {
         var mouse = getMousePosition(canvas);
-        var overNotes = that.pattern.getNotesAtTick(Math.round(mouse.tick), mouse.pitch, mouse.pitch);
+        var singleSelect = true;
+        var overNotes = that.pattern.getNotesAtTick(Math.round(mouse.tick), mouse.pitch, mouse.pitch, singleSelect);
 
         if(button === 2){
           rhomb.Edit.deleteNotes(overNotes, that.ptnId);

--- a/app/assets/templates/pianoroll.html.erb
+++ b/app/assets/templates/pianoroll.html.erb
@@ -1342,8 +1342,7 @@
 
       function handleMousemove() {
         var mouse = getMousePosition(canvas);
-        var singleSelect = true;
-        var overNotes = that.pattern.getNotesAtTick(Math.round(mouse.tick), mouse.pitch, mouse.pitch, singleSelect);
+        var overNotes = that.pattern.getNotesAtTick(Math.round(mouse.tick), mouse.pitch, mouse.pitch);
 
         if(button === 2){
           rhomb.Edit.deleteNotes(overNotes, that.ptnId);

--- a/app/assets/templates/pianoroll.html.erb
+++ b/app/assets/templates/pianoroll.html.erb
@@ -1413,28 +1413,30 @@
             overlayCanvas.style.cursor = "move";
             
             var selectedNotes = that.pattern.getSelectedNotes();
-            deltaTick = (mouse.tick - Xoffset * displaySettings.TPP) - selectedNotes[0].getStart();
-            deltaTick = quantizeFloor(deltaTick);
-            deltaPitch = mouse.pitch - pitchStart;
+            if (selectedNotes.length > 0) {
+              deltaTick = (mouse.tick - Xoffset * displaySettings.TPP) - selectedNotes[0].getStart();
+              deltaTick = quantizeFloor(deltaTick);
+              deltaPitch = mouse.pitch - pitchStart;
 
-            if(rhomb.Edit.isValidTranslation(selectedNotes, deltaPitch, deltaTick)){
-              redrawAllNotes(root, that.pattern.getAllNotes(), displaySettings);
+              if(rhomb.Edit.isValidTranslation(selectedNotes, deltaPitch, deltaTick)){
+                redrawAllNotes(root, that.pattern.getAllNotes(), displaySettings);
 
-              var start;
-              var pitch;
-              for(var i in selectedNotes){
-                previewSet[i]._start = selectedNotes[i].getStart() + deltaTick;
-                previewSet[i]._pitch = selectedNotes[i].getPitch() + deltaPitch;
+                var start;
+                var pitch;
+                for(var i in selectedNotes){
+                  previewSet[i]._start = selectedNotes[i].getStart() + deltaTick;
+                  previewSet[i]._pitch = selectedNotes[i].getPitch() + deltaPitch;
+                }
+
+                if(!event.ctrlKey){
+                  previewNotes(root, previewSet, displaySettings);
+                } else {
+                  drawNotes(root, previewSet, displaySettings);
+                }
+
+                setNotePropertiesPane(previewSet);
+                setGroupPropertiesPane(previewSet);
               }
-
-              if(!event.ctrlKey){
-                previewNotes(root, previewSet, displaySettings);
-              } else {
-                drawNotes(root, previewSet, displaySettings);
-              }
-
-              setNotePropertiesPane(previewSet);
-              setGroupPropertiesPane(previewSet);
             }
           }
           else

--- a/app/assets/templates/pianoroll.html.erb
+++ b/app/assets/templates/pianoroll.html.erb
@@ -1506,13 +1506,16 @@
               // move the notes
               rhomb.Edit.translateNotes(that.ptnId, selectedNotes, deltaPitch, deltaTick);
             } else {
-              // copy the notes
-              that.pattern.clearSelectedNotes();
-              rhomb.Edit.insertNotes(previewSet, that.ptnId, 0);
-              for(var i in previewSet){
-                previewSet[i].select();
+              // copy the notes if the movement distance is at least the quantization value,
+              // or 15 ticks (whichever is greater)
+              if (deltaTick >= 15 && deltaTick >= displaySettings.quantization) {
+                that.pattern.clearSelectedNotes();
+                rhomb.Edit.insertNotes(previewSet, that.ptnId, 0);
+                for(var i in previewSet){
+                  previewSet[i].select();
+                }
+                that.redrawAllNotes();
               }
-              that.redrawAllNotes();
             }
           }
         }


### PR DESCRIPTION
I've added a single-select to Pattern.getNotesAtTick. If the flag is set, instead of returning an array of all notes that fall across a given tick, it returns the shortest note. This is useful for selecting one of two or more overlapping notes.
