### PR TITLE
Effects Graph Changes, Quantization+Automation controls in Pianoroll

### DIFF
--- a/app/assets/templates/automation.html.erb
+++ b/app/assets/templates/automation.html.erb
@@ -91,19 +91,19 @@
         that.ptnId = event.detail.pattern._id;
       });
 
-      // temporary thing to test switching between velocity and parameter automation
-      document.addEventListener("keydown", function(){
-        if(event.keyCode == 86){ // V key
-          that.mode = "velocity";
-          if(typeof that.redrawVelocity !== 'undefined')
-            that.redrawVelocity();
-        } else if(event.keyCode == 80){ // P key
-          that.mode = "parameter";
-          if(typeof that.redrawParameters !== 'undefined')
-            that.redrawParameters();
-        }
+      document.addEventListener('denoto-editvelocity', function(){
+        that.mode = "velocity";
+        that.parameterIndex = undefined;
+        if(typeof that.redrawVelocity !== 'undefined')
+          that.redrawVelocity();
       });
 
+      document.addEventListener('denoto-editparameter', function(){
+        that.parameterIndex = event.detail.parameterIndex;
+        that.mode = "parameter";
+        if(typeof that.redrawParameters !== 'undefined')
+          that.redrawParameters();
+      });
 
       document.addEventListener('denoto-selectmode', function() {
         that.cursormode = 'select';

--- a/app/assets/templates/effectsgraph.html.erb
+++ b/app/assets/templates/effectsgraph.html.erb
@@ -414,6 +414,8 @@
       nodeproperties.style.display = "none";
     };
 
+    fgCanvas.addEventListener("click", this.handleEffectsClick);
+
     this.resizeCanvases = function(){
       var width = window.innerWidth - 410;
       var height = window.innerHeight - 145;
@@ -469,7 +471,6 @@
 
     this.resizeCanvases();
 
-    document.addEventListener('click', this.handleEffectsClick);
     document.addEventListener("denoto-addtrack", this.handleAddTrack);
     document.addEventListener('denoto-deletetrack', this.handleDeleteTrack);
     window.addEventListener('resize', this.resizeCanvases);
@@ -1131,7 +1132,6 @@
   };
 
   effectsgraphPrototype.detachedCallback = function(){
-    document.removeEventListener('click', this.handleEffectsClick);
     document.removeEventListener("denoto-addtrack", this.handleAddTrack);
     document.removeEventListener('denoto-deletetrack', this.handleDeleteTrack);
     window.removeEventListener('resize', this.resizeCanvases);

--- a/app/assets/templates/effectsgraph.html.erb
+++ b/app/assets/templates/effectsgraph.html.erb
@@ -762,11 +762,9 @@
       nodediv.addEventListener("contextmenu", function(n, nd){
         return function(){
           event.preventDefault();
-          // don't create a context menu for the master node, because that lets it be deleted
+          // don't delete the master node
           if(n._id !== 0){
-            var x = event.clientX - parseInt(nd.getBoundingClientRect().left);
-            var y = event.clientY - parseInt(nd.getBoundingClientRect().top);
-            createMenu(root, "nodemenu", nodediv, [{caption: "Remove", click: removeNodeFromGraph}], "Node Options", {x: x, y: y}, n);
+          	removeNodeFromGraph(n);
           }
         }
       }(node, nodediv));

--- a/app/assets/templates/pianoroll.html.erb
+++ b/app/assets/templates/pianoroll.html.erb
@@ -226,6 +226,17 @@
     #preload{
       display: none;
     }
+    .denotobutton{
+      background: #243544;
+      display: inline-block;
+      padding: 10px;
+      margin-right: 10px;
+      margin-left: 10px;
+    }
+    .denotobutton:hover{
+      background: #172837;
+      cursor: pointer;
+    }
   </style>
   <div id="noteproperties">
     <div id="notepropertiesHeader"><h3>Note Properties</h3></div>
@@ -233,22 +244,22 @@
     <p><denoto-editableclock type="shorttext" id="note_length" isposition="false" caption="Length: "></denoto-editableclock></p>
     <p>Pitch: <denoto-editabletext type="shorttext" id="note_pitch"></denoto-editabletext></p>
     <p>Velocity: <denoto-editabletext type="shorttext" id="note_velocity"></denoto-editabletext></p>
-    <p>Auto-adjust <input type="checkbox" id="note_autoadjust" checked></p>
+    <p><div id="note_quantize" class="denotobutton">Quantize Notes</div> Quantize Length <input type="checkbox" id="note_quantize_length" checked></p>
   </div>
+  
   <div id="groupproperties">
     <div id="grouppropertiesHeader"><h3>Group Properties</h3></div>
     <p><denoto-editableclock type="shorttext" id="group_start" isposition="true" caption="Start: "></denoto-editableclock></p>
-    <p>Auto-adjust <input type="checkbox" id="group_autoadjust" checked></p>
+    <p><div id="group_quantize" class="denotobutton">Quantize Notes</div> Quantize Length <input type="checkbox" id="group_quantize_length" checked></p>
   </div>
+  
   <div id="instrumentproperties">
     <div id="instrumentpropertiesHeader"><h3>Properties</h3></div>
-
-    <p> 
-      Insert Velocity
-      <input id="insert_velocity" type="number" value="0.5" min="0" max="1" step="0.01" width="25px">
-    </p>
-
+    <p>Insert Velocity <input id="insert_velocity" type="number" value="0.5" min="0" max="1" step="0.01" width="25px"></p>
+    <p><div id="all_quantize" class="denotobutton">Quantize All Notes</div> Quantize Length <input type="checkbox" id="all_quantize_length" checked></p>
   </div>
+
+
   <div id="kbcover"></div>
   <div id="kbwrapper">
     <denoto-keyboard id="appkeyboard" keycount="128"></denoto-keyboard>
@@ -384,6 +395,39 @@
 
       // set up top bar interface events
       setupTopbarEvents();
+
+      function quantizeSelectedNotes(doEnds){
+        var selectedNotes = that.pattern.getSelectedNotes();
+        rhomb.Edit.quantizeNotes(that.ptnId, selectedNotes, displaySettings.quantization, doEnds);
+        for(var i in selectedNotes){
+          selectedNotes[i].select();
+        }
+      }
+      function quantizeAllNotes(doEnds){
+        var allNotes = that.pattern.getAllNotes();
+        rhomb.Edit.quantizeNotes(that.ptnId, allNotes, displaySettings.quantization, doEnds);
+      }
+      var note_quantize = root.getElementById("note_quantize");
+      note_quantize.addEventListener("mousedown", function(){
+        event.preventDefault();
+        var doEnds = root.getElementById("note_quantize_length").checked;
+        quantizeSelectedNotes(doEnds);
+        that.redrawAllNotes();
+      });
+      var group_quantize = root.getElementById("group_quantize");
+      group_quantize.addEventListener("mousedown", function(){
+        event.preventDefault();
+        var doEnds = root.getElementById("group_quantize_length").checked;
+        quantizeSelectedNotes(doEnds);
+        that.redrawAllNotes();
+      });
+      var all_quantize = root.getElementById("all_quantize");
+      all_quantize.addEventListener("mousedown", function(){
+        event.preventDefault();
+        var doEnds = root.getElementById("all_quantize_length").checked;
+        quantizeAllNotes(doEnds);
+        that.redrawAllNotes();
+      });
 
       // give the parameter automation a reference to the display settings
       var displaysettingsEvent = new CustomEvent('denoto-displaysettings', {"detail": {"displaySettings": displaySettings}});

--- a/app/assets/templates/pianoroll.html.erb
+++ b/app/assets/templates/pianoroll.html.erb
@@ -257,6 +257,16 @@
     <div id="instrumentpropertiesHeader"><h3>Properties</h3></div>
     <p>Insert Velocity <input id="insert_velocity" type="number" value="0.5" min="0" max="1" step="0.01" width="25px"></p>
     <p><div id="all_quantize" class="denotobutton">Quantize All Notes</div> Quantize Length <input type="checkbox" id="all_quantize_length" checked></p>
+
+    <p>Automation Lane: <select id="all_automation_select">
+        <option value="Velocity" selected="selected">Velocity</option>
+        <option value="1">Control Signal 1</option>
+        <option value="2">Control Signal 2</option>
+        <option value="3">Control Signal 3</option>
+        <option value="4">Control Signal 4</option>
+        <option value="5">Control Signal 5</option>
+      </select>
+    </p>
   </div>
 
 
@@ -427,6 +437,18 @@
         var doEnds = root.getElementById("all_quantize_length").checked;
         quantizeAllNotes(doEnds);
         that.redrawAllNotes();
+      });
+      var all_automation_select = root.getElementById("all_automation_select");
+      all_automation_select.addEventListener("change", function(){
+        var value = event.srcElement.value;
+        if(value === "Velocity"){
+          var autoEvent = new CustomEvent("denoto-editvelocity", {});
+          document.dispatchEvent(autoEvent);
+        } else {
+          value = parseInt(value);
+          var autoEvent = new CustomEvent("denoto-editparameter", {"detail": {"parameterIndex": value}});
+          document.dispatchEvent(autoEvent);
+        }
       });
 
       // give the parameter automation a reference to the display settings


### PR DESCRIPTION
Right-click-to-remove has been implemented on effects graph nodes, and using the transport bar no longer deselects them.

A quantize button has been added to each properties pane (note/group/all) in the pianoroll.

A drop-down to select what to automate has been added to the pianoroll. Control Signals 1 through 5 are currently the same thing. It's trivial to change the drop-down to use a single parameter if we end up not being able to use all 5 in the demo release.
