### PR TITLE
Tabs, Menus, and Quantized Movement

### DIFF
--- a/app/assets/javascripts/menu.js
+++ b/app/assets/javascripts/menu.js
@@ -14,6 +14,9 @@ function createMenu(root, id, parent, options, caption, pos, obj){
   if(typeof root === 'undefined')
     root = document;
 
+  if(typeof deleteAfterClick === 'undefined')
+    deleteAfterClick = false;
+
   if(typeof pos === 'undefined'){
     pos.x = parseInt(parent.style.right);
     pos.y = parseInt(parent.style.top);
@@ -38,8 +41,30 @@ function createMenu(root, id, parent, options, caption, pos, obj){
   menu.style.position = "absolute";
   parent.appendChild(menu);
 
+  var bgdiv = document.createElement("div");
+  bgdiv.setAttribute("id", "bgdiv" + id);
+  bgdiv.style.display = "block";
+  bgdiv.style.position = "absolute";
+  bgdiv.style.background = "#FF0000";
+  bgdiv.style.opacity = "0";
+  bgdiv.style.left = "0px";
+  bgdiv.style.top = "0px";
+  menu.appendChild(bgdiv);
+
+  function resizeBgdiv(){
+    if(parent.parentNode.id === "outer")
+      return;
+
+    bgdiv.style.left = -(parent.parentNode.getBoundingClientRect().width - 20) + "px";
+    bgdiv.style.top = (parent.parentNode.getBoundingClientRect().height - 35) + "px";
+    bgdiv.style.height = ((parent.parentNode.getBoundingClientRect().height + menu.getBoundingClientRect().height) * 0.5) + "px";
+    bgdiv.style.width = (parent.parentNode.getBoundingClientRect().width - 20) + "px";
+  }
+
   // remove the menu when the user's mouse has left its listener
-  parent.addEventListener("mouseleave", deleteMenu);
+  if(parent.parentNode.id === "outer")
+    parent.addEventListener("mouseleave", deleteMenu);
+  parent.parentNode.addEventListener("mouseleave", deleteMenu);
 
   if(typeof caption !== 'undefined' && caption.trim() !== ""){
     var header = document.createElement("div");
@@ -63,7 +88,6 @@ function createMenu(root, id, parent, options, caption, pos, obj){
       div.addEventListener("click", function(o, opt){
         return function(){
           opt.click(o);
-          deleteMenu();
         }
       }(obj, option));
     }
@@ -82,6 +106,8 @@ function createMenu(root, id, parent, options, caption, pos, obj){
       }(obj, option));
     }
   }
+
+  resizeBgdiv(); // make the background div show up if this is a submenu
 
   return menu;
 }

--- a/app/assets/templates/effectsgraph.html.erb
+++ b/app/assets/templates/effectsgraph.html.erb
@@ -1008,6 +1008,9 @@
 
         // redraw the background lines
         drawBG();
+
+        // remove the menu when done
+        parent.parentNode.removeChild(parent);
       };
     }
 
@@ -1033,6 +1036,9 @@
 
         // redraw the background lines
         drawBG();
+
+        // remove the menu when done
+        parent.parentNode.removeChild(parent);
       };
     }
 
@@ -1044,6 +1050,11 @@
         options.push({caption: effectNames[i], id: "effect_" + effectTypes[i], click: effectCreator(effectTypes[i], "ctxmenu")}); 
       }
       
+      // remove competing menu
+      var instrMenu = root.getElementById("instrumentsmenu");
+      if(instrMenu !== null)
+      	instrMenu.parentNode.removeChild(instrMenu);
+
       createMenu(root, "effectsmenu", parent, options, "Insert Effect", pos, undefined);
     }
 
@@ -1056,21 +1067,28 @@
         options.push({caption: instrNames[i], id: "instr_" + instrTypes[i], click: instrumentCreator(instrTypes[i], "ctxmenu", sampleSets[i])}); 
       }
       
+      // remove competing menu
+      var effectsMenu = root.getElementById("effectsmenu");
+      if(effectsMenu !== null)
+      	effectsMenu.parentNode.removeChild(effectsMenu);
+      
       createMenu(root, "instrumentsmenu", parent, options, "Insert Instrument", pos, undefined);
     }
 
     function createContextMenu(pos, parent){
       var options = new Array();
-      options.push({caption: "Effects", id: "effects_option", mouseenter: function(){createSubMenu("effects_option", createEffectsMenu);} });
-      options.push({caption: "Instruments", id: "instruments_option", mouseenter: function(){createSubMenu("instruments_option", createInstrumentsMenu);} });
+      options.push({caption: "Effects", id: "effects_option", click: function(){createSubMenu("effects_option", createEffectsMenu);} });
+      options.push({caption: "Instruments", id: "instruments_option", click: function(){createSubMenu("instruments_option", createInstrumentsMenu);} });
       createMenu(root, "ctxmenu", parent, options, "Insert Graph Node", pos, undefined);
     }
 
     function createSubMenu(parentId, delegate){
       var parent = root.getElementById(parentId);
-      var rect = parent.getBoundingClientRect();
-      var pos = {x: rect.width-1, y: 30};
-      delegate(pos, parent);
+      if(parent !== null){
+	      var rect = parent.getBoundingClientRect();
+	      var pos = {x: rect.width-1, y: 30};
+	      delegate(pos, parent);
+    	}
     }
 
     function removeNodeFromGraph(node){

--- a/app/assets/templates/pianoroll.html.erb
+++ b/app/assets/templates/pianoroll.html.erb
@@ -1437,7 +1437,7 @@
             overlayCanvas.style.cursor = "ew-resize";
             
             var selectedNotes = that.pattern.getSelectedNotes();
-            deltaTick = (mouse.tick - Xoffset * displaySettings.TPP);// - (selectedNotes[0].getStart() + selectedNotes[0].getLength());
+            deltaTick = (mouse.tick - Xoffset * displaySettings.TPP);
             deltaTick = quantizeCeil(deltaTick);
             
             redrawAllNotes(root, that.pattern.getAllNotes(), displaySettings);
@@ -1490,7 +1490,7 @@
                 var start;
                 var pitch;
                 for(var i in selectedNotes){
-                  previewSet[i]._start = selectedNotes[i].getStart() + deltaTick;
+                  previewSet[i]._start = quantizeFloor(selectedNotes[i].getStart() + deltaTick); // quantizeFloor takes display.snapTo into consideration
                   previewSet[i]._pitch = selectedNotes[i].getPitch() + deltaPitch;
                 }
 
@@ -1571,6 +1571,10 @@
             if(!event.ctrlKey){
               // move the notes
               rhomb.Edit.translateNotes(that.ptnId, selectedNotes, deltaPitch, deltaTick);
+              if(displaySettings.snapTo){
+                rhomb.Edit.quantizeNotes(that.ptnId, selectedNotes, displaySettings.quantization, false);
+              }
+              redrawAllNotes();
             } else {
               // copy the notes if the movement distance is at least the quantization value,
               // or 15 ticks (whichever is greater)

--- a/app/assets/templates/tab.html.erb
+++ b/app/assets/templates/tab.html.erb
@@ -103,8 +103,10 @@
       });
 
       document.addEventListener("denoto-editpattern", function() {
-        if (that.getAttribute("id") === ("pattern" + event.detail.pattern._id))
+        if (that.getAttribute("id") === ("pattern" + event.detail.pattern._id)){
           root.getElementById("container").className = "tabselected";
+          that.playlistItemId = event.detail.playlistItem._id;
+        }
         else
           root.getElementById("container").className = "";
       });
@@ -121,6 +123,14 @@
           root.getElementById("container").className = "tabselected";
         else
           root.getElementById("container").className = "";
+      });
+
+      root.host.addEventListener("denoto-deletedplaylistitem", function(){
+        // if the last-opened instance of a pattern was deleted, close the tab
+        if(event.detail.playlistItemId === this.playlistItemId){
+          var parent = root.host.parentNode;
+          parent.removeChild(root.host);
+        }
       });
 
       root.host.addEventListener("denoto-displaysettings", function(){

--- a/app/assets/templates/trackview.html.erb
+++ b/app/assets/templates/trackview.html.erb
@@ -1691,6 +1691,13 @@
           if (typeof trackset.currentPattern !== 'undefined') {
             erasePattern(context, trackset.currentPattern, displaySettings);
 
+            // delete the tab for this playlistItem if it was the last one of its kind viewed
+            var tab = document.getElementById("tabset").shadowRoot.getElementById("pattern" + trackset.currentPattern._ptnId);
+            if(tab !== null && typeof tab !== 'undefined'){
+              var tabEvent = new CustomEvent("denoto-deletedplaylistitem", {"detail": {"playlistItemId": trackset.currentPattern._id}});
+              tab.dispatchEvent(tabEvent);
+            }
+
             // dispatch the event so that listeners can handle it
             trackset.RemovePattern(trackset.currentPattern);
             trackset.currentPattern = undefined;


### PR DESCRIPTION
Tabs for dead playlistitems are now removed.

The context menu in the effects graph is far less finicky and should now always disappear when instruments/effects are inserted.

Quantized note movement has been fixed, although it currently generates two Undo events (a translateNotes and a quantizeNotes).
