### PR TITLE
Fixed getNotesAtTick

### DIFF
--- a/app/assets/javascripts/rhombus.js
+++ b/app/assets/javascripts/rhombus.js
@@ -3109,7 +3109,7 @@ Rhombus.Pattern.prototype.getNotesAtTick = function(tick, lowPitch, highPitch, s
 
     // ignore already-selected notes
     if (note._selected) {
-      continue;
+      return [note];
     }
 
     // find the shortest note


### PR DESCRIPTION
Move after pasting works like a charm now.
